### PR TITLE
Implementing AssetBundles Browser Client

### DIFF
--- a/GooglePlayInstant/Editor/PlayInstantAssetBundleBrowserClient.cs
+++ b/GooglePlayInstant/Editor/PlayInstantAssetBundleBrowserClient.cs
@@ -63,14 +63,6 @@ namespace GooglePlayInstant.Editor
             return false;
         }
 
-        // Evaluates whether a folder has "AssetBundles-Browser" in its name, making it
-        // a candidate for the Asset Bundles Browser Folder.
-        private static bool IsAssetBundleBrowserFolder(string folderName)
-        {
-            var regex = new Regex(@"AssetBundles-Browser", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            return regex.Matches(folderName).Count > 0;
-        }
-
         /// <summary>
         /// Get the version of Asset Bundle Browser if available in the package information.
         /// </summary>
@@ -87,8 +79,10 @@ namespace GooglePlayInstant.Editor
             }
 
             // Extract AssetBundleBrowser version name from the Asset Bundle Browser package.json file.
+            // All forlders with "AssetBundles-Browser" in their names are considered candidates
             var assetBundleBrowserFolderPaths =
-                Directory.GetDirectories(Application.dataPath).ToArray().Where(IsAssetBundleBrowserFolder);
+                Directory.GetDirectories(Application.dataPath).ToArray().Where(folderName =>
+                    Regex.IsMatch(folderName, "AssetBundles-Browser", RegexOptions.IgnoreCase));
             foreach (var folderPath in assetBundleBrowserFolderPaths)
             {
                 var expectedPackageDotJsonPath = Path.Combine(folderPath, "package.json");

--- a/GooglePlayInstant/Editor/PlayInstantAssetBundleBrowserClient.cs
+++ b/GooglePlayInstant/Editor/PlayInstantAssetBundleBrowserClient.cs
@@ -18,7 +18,6 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-
 namespace GooglePlayInstant.Editor
 {
     public static class AssetBundleBrowserClient

--- a/GooglePlayInstant/Editor/PlayInstantAssetBundleBrowserClient.cs
+++ b/GooglePlayInstant/Editor/PlayInstantAssetBundleBrowserClient.cs
@@ -90,7 +90,6 @@ namespace GooglePlayInstant.Editor
                 {
                 }
             }
-
             return "not found";
         }
 
@@ -101,7 +100,6 @@ namespace GooglePlayInstant.Editor
             {
                 throw new Exception("Cannot detect Unity Asset Bundle Browser");
             }
-
             EditorApplication.ExecuteMenuItem(AssetBundleBrowserMenuItem);
         }
 

--- a/GooglePlayInstant/Editor/PlayInstantAssetBundleBrowserClient.cs
+++ b/GooglePlayInstant/Editor/PlayInstantAssetBundleBrowserClient.cs
@@ -1,0 +1,102 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+
+namespace GooglePlayInstant.Editor
+{
+    public static class AssetBundleBrowserClient
+    {
+        private const string AssetBundleBrowserMenuItem = "Window/AssetBundle Browser";
+        private static bool? _assetBundleBrowserIsPresent;
+
+
+        // Detects AssetBundleBrowser Namespace and the AssetBundleBrowserMain Class
+        public static bool BundleBrowserIsPresent()
+        {
+            if (_assetBundleBrowserIsPresent.HasValue) return _assetBundleBrowserIsPresent.Value;
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (assembly == null) continue;
+                foreach (var type in assembly.GetTypes())
+                {
+                    // Look for AssetBundleBrowserMain in the AssetBundleBrowser Namespace
+                    if (type != null && type.Namespace != null && type.Namespace.Equals("AssetBundleBrowser") &&
+                        type.Name.Equals("AssetBundleBrowserMain"))
+                    {
+                        _assetBundleBrowserIsPresent = true;
+                        return _assetBundleBrowserIsPresent.Value;
+                    }
+                }
+            }
+
+            _assetBundleBrowserIsPresent = false;
+            return false;
+        }
+
+        public static string BundleBrowserVersion => GetBrowserVersion(GetAssetBundlesBrowserPackageDotSONFiles()); 
+        
+
+        // Get package.json files related to AssetBundles Browser
+        private static string[] GetAssetBundlesBrowserPackageDotSONFiles()
+        {
+            var assetsPath = Application.dataPath;
+            var files = Directory.GetFiles(assetsPath, "package.json", SearchOption.AllDirectories);
+            return files.Where(f => f.Contains("AssetBundle") && f.Contains("Browser")).ToArray();
+        }
+
+        // Extract the version from the package.json.
+        // Goes line by line since there is no guarantee that any given file will be a valid well formatted JSON file
+        private static string GetBrowserVersion(string[] filePaths)
+        {
+            foreach (var filePath in filePaths)
+            {
+                var allText = File.ReadAllText(filePath);
+                if (!allText.ToLower().Contains("\"name\": \"com.unity.assetbundlebrowser\"")) continue;
+                var fileStream = new StreamReader(filePath);
+                const string versionMatcher = "version\":";
+                string line;
+                while ((line = fileStream.ReadLine()) != null)
+                {
+                    if (line.Contains(versionMatcher))
+                    {
+                        var versionBeginIndex = line.IndexOf(versionMatcher) + versionMatcher.Length;
+                        var version = line.Substring(versionBeginIndex);
+                        if (!version.Trim().Equals(""))
+                        {
+                            return version.Trim().Replace(",", "");
+                        }
+                    }
+                }
+            }
+
+            return "not found";
+        }
+        
+        // Displays AssetBundleBrowser
+        public static void DisplayAssetBundleBrowser()
+        {
+            if (!BundleBrowserIsPresent())
+            {
+                throw new Exception("Cannot detect AssetBundleBrowser Context");
+            }
+            EditorApplication.ExecuteMenuItem(AssetBundleBrowserMenuItem);
+        }
+    }
+}

--- a/GooglePlayInstant/Editor/PlayInstantAssetBundleBrowserClient.cs
+++ b/GooglePlayInstant/Editor/PlayInstantAssetBundleBrowserClient.cs
@@ -32,7 +32,11 @@ namespace GooglePlayInstant.Editor
         private const string AssetBundleBrowserMenuItem = "Window/AssetBundle Browser";
         private static bool? _assetBundleBrowserIsPresent;
         private static string _assetBundleBrowserVersion;
-
+        
+        
+        /// <summary>
+        /// Determine whether Asset Bundle Browser is present based on the currently loaded assemblies.
+        /// </summary>
         /// <param name="useCurrentValueIfPresent">A boolean value corresponding to whether the caller wants to
         /// to re-use the cached value if it is present. Using the default value(true) provides a significant
         /// peformance improvement when calling this method from functions that are invoked so many times
@@ -79,7 +83,7 @@ namespace GooglePlayInstant.Editor
             }
 
             // Extract AssetBundleBrowser version name from the Asset Bundle Browser package.json file.
-            // All forlders with "AssetBundles-Browser" in their names are considered candidates
+            // All folders with "AssetBundles-Browser" in their names are considered candidates.
             var assetBundleBrowserFolderPaths =
                 Directory.GetDirectories(Application.dataPath).ToArray().Where(folderName =>
                     Regex.IsMatch(folderName, "AssetBundles-Browser", RegexOptions.IgnoreCase));

--- a/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
@@ -21,9 +21,13 @@ namespace GooglePlayInstant.Editor
     public class PlayInstantQuickDeployWindow : EditorWindow
     {
         private static int _toolbarSelectedButtonIndex = 0;
-        private static readonly string[] ToolbarButtonNames = {"Create Bundle", "Deploy Bundle", "Verify Bundle", 
-            "Loading Screen", "Build"};
-        
+
+        private static readonly string[] ToolbarButtonNames =
+        {
+            "Create Bundle", "Deploy Bundle", "Verify Bundle",
+            "Loading Screen", "Build"
+        };
+
         public enum ToolBarSelectedButton
         {
             CreateBundle,
@@ -47,9 +51,10 @@ namespace GooglePlayInstant.Editor
         void OnGUI()
         {
             _toolbarSelectedButtonIndex = GUILayout.Toolbar(_toolbarSelectedButtonIndex, ToolbarButtonNames);
-            switch((ToolBarSelectedButton) _toolbarSelectedButtonIndex) 
+            switch ((ToolBarSelectedButton) _toolbarSelectedButtonIndex)
             {
                 case ToolBarSelectedButton.CreateBundle:
+                    AssetBundleBrowserClient.ReloadAndUpdateBrowserInfo();
                     OnGuiCreateBundleSelect();
                     break;
                 case ToolBarSelectedButton.DeployBundle:
@@ -67,46 +72,55 @@ namespace GooglePlayInstant.Editor
             }
         }
 
-        private void OnGuiCreateBundleSelect() 
+        private void OnGuiCreateBundleSelect()
         {
             EditorGUILayout.LabelField("AssetBundle Creation", EditorStyles.boldLabel);
-            EditorGUILayout.LabelField("Use the Unity Asset Bundle Browser to select your game's main scene " + 
-                                       "and bundle it (and its dependencies) into an AssetBundle file.", EditorStyles.wordWrappedLabel);
+            EditorGUILayout.LabelField("Use the Unity Asset Bundle Browser to select your game's main scene " +
+                                       "and bundle it (and its dependencies) into an AssetBundle file.",
+                EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField(string.Format("Asset Bundle Browser version: {0}", AssetBundleBrowserClient.AssetBundleBrowserVersion ),  EditorStyles.wordWrappedLabel);
+            EditorGUILayout.LabelField(
+                string.Format("Asset Bundle Browser version: {0}", AssetBundleBrowserClient.AssetBundleBrowserVersion),
+                EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
-            
+
             // Allow the developer to open the AssetBundles Browser if it is present, otherwise ask them to download it
-            if (AssetBundleBrowserClient.BundleBrowserIsPresent())
+            if (AssetBundleBrowserClient.AssetBundleBrowserIsPresent)
             {
-                var openAssetBundleBrowser = GUILayout.Button ("Open Asset Bundle Browser", GUILayout.Width(ButtonWidth));
+                var openAssetBundleBrowser =
+                    GUILayout.Button("Open Asset Bundle Browser", GUILayout.Width(ButtonWidth));
                 if (openAssetBundleBrowser)
                 {
                     AssetBundleBrowserClient.DisplayAssetBundleBrowser();
                 }
-            } else
+            }
+            else
             {
-                var downloadAssetBundleBrowser =  GUILayout.Button ("Download Asset Bundle Browser from GitHub", GUILayout.Width(LongButtonWidth));
+                var downloadAssetBundleBrowser = GUILayout.Button("Download Asset Bundle Browser from GitHub",
+                    GUILayout.Width(LongButtonWidth));
                 if (downloadAssetBundleBrowser)
                 {
                     Application.OpenURL("https://github.com/Unity-Technologies/AssetBundles-Browser/releases");
                 }
+
                 EditorGUILayout.Space();
-                
-                var viewAssetBundleBrowserDocumentation =  GUILayout.Button ("Open Asset Bundle Browser Documentation", GUILayout.Width(LongButtonWidth));
+
+                var viewAssetBundleBrowserDocumentation = GUILayout.Button("Open Asset Bundle Browser Documentation",
+                    GUILayout.Width(LongButtonWidth));
                 if (viewAssetBundleBrowserDocumentation)
                 {
                     Application.OpenURL("https://docs.unity3d.com/Manual/AssetBundles-Browser.html");
                 }
+
                 EditorGUILayout.Space();
-            } 
+            }
         }
 
-        private void OnGuiDeployBundleSelect() 
+        private void OnGuiDeployBundleSelect()
         {
             EditorGUILayout.LabelField("AssetBundle Deployment", EditorStyles.boldLabel);
             EditorGUILayout.LabelField("Use the Google Cloud Storage to host the AssetBundle as a public " +
-                "file. Or host the file on your own CDN.", EditorStyles.wordWrappedLabel);
+                                       "file. Or host the file on your own CDN.", EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
             EditorGUILayout.BeginHorizontal();
             EditorGUILayout.LabelField("Asset Bundle File Name", GUILayout.MinWidth(FieldMinWidth));
@@ -127,44 +141,46 @@ namespace GooglePlayInstant.Editor
             EditorGUILayout.LabelField("PCloud Credentials", GUILayout.MinWidth(FieldMinWidth));
             EditorGUILayout.TextField("c:\\path\\to\\credentials.json", GUILayout.MinWidth(FieldMinWidth));
             EditorGUILayout.EndHorizontal();
-            GUILayout.Button ("Upload to Cloud Storage", GUILayout.Width(ButtonWidth));
+            GUILayout.Button("Upload to Cloud Storage", GUILayout.Width(ButtonWidth));
             EditorGUILayout.Space();
-            GUILayout.Button ("Open Cloud Storage Console", GUILayout.Width(ButtonWidth));     
+            GUILayout.Button("Open Cloud Storage Console", GUILayout.Width(ButtonWidth));
         }
 
-        private void OnGuiVerifyBundleSelect() 
+        private void OnGuiVerifyBundleSelect()
         {
             EditorGUILayout.LabelField("AssetBundle Verification", EditorStyles.boldLabel);
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Verifies that the file at the specified URL is available and reports " +
-                "metadata including file version and compression type.", EditorStyles.wordWrappedLabel);
+                                       "metadata including file version and compression type.",
+                EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
             EditorGUILayout.BeginHorizontal();
             EditorGUILayout.LabelField("AssetBundle URL", GUILayout.MinWidth(FieldMinWidth));
-            EditorGUILayout.TextField("http://storage.googleapis.com/mycorp_awesome_game/mainscene", 
+            EditorGUILayout.TextField("http://storage.googleapis.com/mycorp_awesome_game/mainscene",
                 GUILayout.MinWidth(FieldMinWidth));
             EditorGUILayout.EndHorizontal();
             EditorGUILayout.Space();
             EditorGUILayout.BeginVertical();
-            GUILayout.Button ("Verify AssetBundle", GUILayout.Width(ButtonWidth));
+            GUILayout.Button("Verify AssetBundle", GUILayout.Width(ButtonWidth));
             EditorGUILayout.EndVertical();
         }
 
-        private void OnGuiLoadingScreenSelect() 
+        private void OnGuiLoadingScreenSelect()
         {
             EditorGUILayout.LabelField("Loading Screen", EditorStyles.boldLabel);
             EditorGUILayout.LabelField("A loading screen scene displays a progress bar over the image " +
-                "specified below while downloading and opening the main scene.", EditorStyles.wordWrappedLabel);
+                                       "specified below while downloading and opening the main scene.",
+                EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
             EditorGUILayout.BeginHorizontal();
             EditorGUILayout.LabelField("Image File Name", GUILayout.MinWidth(FieldMinWidth));
             EditorGUILayout.TextField("c:\\loading.png", GUILayout.MinWidth(FieldMinWidth));
             EditorGUILayout.EndHorizontal();
             EditorGUILayout.Space();
-            GUILayout.Button ("Create Loading Scene", GUILayout.Width(ButtonWidth));
+            GUILayout.Button("Create Loading Scene", GUILayout.Width(ButtonWidth));
         }
 
-        private void OnGuiCreateBuildSelect() 
+        private void OnGuiCreateBuildSelect()
         {
             EditorGUILayout.LabelField("Deployment", EditorStyles.boldLabel);
             EditorGUILayout.LabelField("Build the APK using the IL2CPP engine.", EditorStyles.wordWrappedLabel);
@@ -174,7 +190,7 @@ namespace GooglePlayInstant.Editor
             EditorGUILayout.TextField("c:\\base.apk", GUILayout.MinWidth(FieldMinWidth));
             EditorGUILayout.EndHorizontal();
             EditorGUILayout.Space();
-            GUILayout.Button ("Build Base APK", GUILayout.Width(ButtonWidth));
+            GUILayout.Button("Build Base APK", GUILayout.Width(ButtonWidth));
         }
     }
 }

--- a/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
@@ -14,6 +14,7 @@
 
 using UnityEditor;
 using UnityEngine;
+using System.Diagnostics;
 
 namespace GooglePlayInstant.Editor
 {
@@ -68,14 +69,29 @@ namespace GooglePlayInstant.Editor
         private void OnGuiCreateBundleSelect() 
         {
             EditorGUILayout.LabelField("AssetBundle Creation", EditorStyles.boldLabel);
-            EditorGUILayout.LabelField("Use the Unity Asset Bundle Browser to select your game's main scene " + 
-                "and bundle it (and its dependencies) into an AssetBundle file.", EditorStyles.wordWrappedLabel);
+            EditorGUILayout.LabelField("Use the Unity AssetBundles Browser to select your game's main scene " + 
+                                       "and bundle it (and its dependencies) into an AssetBundle file.", EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField(string.Format("AssetBundle Browser version: {0}", "not found"), EditorStyles.wordWrappedLabel);
+            EditorGUILayout.LabelField($"AssetBundle Browser version: { AssetBundleBrowserClient.BundleBrowserVersion }",  EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
-            GUILayout.Button ("Download AssetBundle Browser", GUILayout.Width(ButtonWidth));
-            EditorGUILayout.Space();
-            GUILayout.Button ("Open AssetBundle Browser", GUILayout.Width(ButtonWidth));
+            
+            // Allow the developer to open the AssetBundles Browser if it is present, otherwise ask them to download it
+            if (AssetBundleBrowserClient.BundleBrowserIsPresent())
+            {
+                var openAssetBundleBrowser = GUILayout.Button ("Open AssetBundles Browser", GUILayout.Width(ButtonWidth));
+                if (openAssetBundleBrowser)
+                {
+                    AssetBundleBrowserClient.DisplayAssetBundleBrowser();
+                }
+            } else 
+            {
+                var downloadAssetBundleBrowser =  GUILayout.Button ("Download AssetBundles Browser", GUILayout.Width(ButtonWidth));
+                if (downloadAssetBundleBrowser)
+                {
+                    Process.Start("https://docs.unity3d.com/Manual/AssetBundles-Browser.html");
+                }
+                EditorGUILayout.Space();
+            } 
         }
 
         private void OnGuiDeployBundleSelect() 

--- a/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
@@ -14,7 +14,6 @@
 
 using UnityEditor;
 using UnityEngine;
-using System.Diagnostics;
 
 namespace GooglePlayInstant.Editor
 {
@@ -80,16 +79,15 @@ namespace GooglePlayInstant.Editor
                 EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
             EditorGUILayout.LabelField(
-                string.Format("Asset Bundle Browser version: {0}", AssetBundleBrowserClient.AssetBundleBrowserVersion),
+                string.Format("Asset Bundle Browser version: {0}",
+                    AssetBundleBrowserClient.GetAssetBundleBrowserVersion()),
                 EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
 
             // Allow the developer to open the AssetBundles Browser if it is present, otherwise ask them to download it
-            if (AssetBundleBrowserClient.AssetBundleBrowserIsPresent)
+            if (AssetBundleBrowserClient.AssetBundleBrowserIsPresent())
             {
-                var openAssetBundleBrowser =
-                    GUILayout.Button("Open Asset Bundle Browser", GUILayout.Width(ButtonWidth));
-                if (openAssetBundleBrowser)
+                if (GUILayout.Button("Open Asset Bundle Browser", GUILayout.Width(ButtonWidth)))
                 {
                     AssetBundleBrowserClient.DisplayAssetBundleBrowser();
                 }
@@ -104,10 +102,7 @@ namespace GooglePlayInstant.Editor
                 }
 
                 EditorGUILayout.Space();
-
-                var viewAssetBundleBrowserDocumentation = GUILayout.Button("Open Asset Bundle Browser Documentation",
-                    GUILayout.Width(LongButtonWidth));
-                if (viewAssetBundleBrowserDocumentation)
+                if (GUILayout.Button("Open Asset Bundle Browser Documentation", GUILayout.Width(LongButtonWidth)))
                 {
                     Application.OpenURL("https://docs.unity3d.com/Manual/AssetBundles-Browser.html");
                 }

--- a/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
@@ -35,6 +35,7 @@ namespace GooglePlayInstant.Editor
 
         private const int FieldMinWidth = 100;
         private const int ButtonWidth = 200;
+        private const int LongButtonWidth = 300;
 
         public static void ShowWindow(ToolBarSelectedButton select)
         {
@@ -72,23 +73,30 @@ namespace GooglePlayInstant.Editor
             EditorGUILayout.LabelField("Use the Unity AssetBundles Browser to select your game's main scene " + 
                                        "and bundle it (and its dependencies) into an AssetBundle file.", EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField($"AssetBundle Browser version: { AssetBundleBrowserClient.BundleBrowserVersion }",  EditorStyles.wordWrappedLabel);
+            EditorGUILayout.LabelField(string.Format("AssetBundle Browser version: {0}", AssetBundleBrowserClient.AssetBundleBrowserVersion ),  EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
             
             // Allow the developer to open the AssetBundles Browser if it is present, otherwise ask them to download it
             if (AssetBundleBrowserClient.BundleBrowserIsPresent())
             {
-                var openAssetBundleBrowser = GUILayout.Button ("Open AssetBundles Browser", GUILayout.Width(ButtonWidth));
+                var openAssetBundleBrowser = GUILayout.Button ("Open Asset Bundle Browser", GUILayout.Width(ButtonWidth));
                 if (openAssetBundleBrowser)
                 {
                     AssetBundleBrowserClient.DisplayAssetBundleBrowser();
                 }
-            } else 
+            } else
             {
-                var downloadAssetBundleBrowser =  GUILayout.Button ("Download AssetBundles Browser", GUILayout.Width(ButtonWidth));
+                var downloadAssetBundleBrowser =  GUILayout.Button ("Download Asset Bundle Browser from GitHub", GUILayout.Width(LongButtonWidth));
                 if (downloadAssetBundleBrowser)
                 {
-                    Process.Start("https://docs.unity3d.com/Manual/AssetBundles-Browser.html");
+                    Application.OpenURL("https://github.com/Unity-Technologies/AssetBundles-Browser/releases");
+                }
+                EditorGUILayout.Space();
+                
+                var viewAssetBundleBrowserDocumentation =  GUILayout.Button ("Open Asset Bundle Browser Documentation", GUILayout.Width(LongButtonWidth));
+                if (viewAssetBundleBrowserDocumentation)
+                {
+                    Application.OpenURL("https://docs.unity3d.com/Manual/AssetBundles-Browser.html");
                 }
                 EditorGUILayout.Space();
             } 

--- a/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
@@ -94,9 +94,7 @@ namespace GooglePlayInstant.Editor
             }
             else
             {
-                var downloadAssetBundleBrowser = GUILayout.Button("Download Asset Bundle Browser from GitHub",
-                    GUILayout.Width(LongButtonWidth));
-                if (downloadAssetBundleBrowser)
+                if (GUILayout.Button("Download Asset Bundle Browser from GitHub", GUILayout.Width(LongButtonWidth)))
                 {
                     Application.OpenURL("https://github.com/Unity-Technologies/AssetBundles-Browser/releases");
                 }

--- a/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
@@ -70,10 +70,10 @@ namespace GooglePlayInstant.Editor
         private void OnGuiCreateBundleSelect() 
         {
             EditorGUILayout.LabelField("AssetBundle Creation", EditorStyles.boldLabel);
-            EditorGUILayout.LabelField("Use the Unity AssetBundles Browser to select your game's main scene " + 
+            EditorGUILayout.LabelField("Use the Unity Asset Bundle Browser to select your game's main scene " + 
                                        "and bundle it (and its dependencies) into an AssetBundle file.", EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField(string.Format("AssetBundle Browser version: {0}", AssetBundleBrowserClient.AssetBundleBrowserVersion ),  EditorStyles.wordWrappedLabel);
+            EditorGUILayout.LabelField(string.Format("Asset Bundle Browser version: {0}", AssetBundleBrowserClient.AssetBundleBrowserVersion ),  EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
             
             // Allow the developer to open the AssetBundles Browser if it is present, otherwise ask them to download it


### PR DESCRIPTION
Implemented AssetBundles Browser Client and Changed the "Create Bundle" section in the UI to accomodate this

#### With AssetBundle Browser present:
<img width="684" alt="browser_present" src="https://user-images.githubusercontent.com/18396695/42644069-81a4fcd6-85af-11e8-8e9b-d2cd4743b51d.png">

#### With AssetBundle Browser not present:

<img width="712" alt="browser_absent" src="https://user-images.githubusercontent.com/18396695/42644126-a4909156-85af-11e8-9507-0c5a996c0399.png">
