### PR TITLE
Verify Bundle Loading Bar + Mended malformed URL behavior

### DIFF
--- a/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
@@ -50,6 +50,13 @@ namespace GooglePlayInstant.Editor
         //TODO: Support Unity 5.6.0+
         private void StartAssetBundleVerificationDownload()
         {
+            if (string.IsNullOrEmpty(_assetBundleUrl))
+            {
+                _assetBundleDownloadIsSuccessful = false;
+                Debug.Log("Problem retrieving AssetBundle: URL is null or empty.");
+                _errorDescription = "URL is null or empty.";
+                return;
+            }
             _webRequest = UnityWebRequestAssetBundle.GetAssetBundle(_assetBundleUrl);
             _webRequest.SendWebRequest();
         }
@@ -93,7 +100,6 @@ namespace GooglePlayInstant.Editor
             return bytes / 1024f / 1024f;
         }
 
-        //TODO: fix malformed url behavior
         private void Update()
         {
             if (_webRequest == null || !_webRequest.isDone)
@@ -103,12 +109,11 @@ namespace GooglePlayInstant.Editor
             GetAssetBundleInfoFromDownload();
             Repaint();
             
-            // Turn request to null to be prepared for next call
+            // Turn request to null to signal ready for next call
             _webRequest.Dispose();
             _webRequest = null;
         }
 
-        //TODO: add a loading state so client knows that some loading is going on behind the scenes.
         private void OnGUI()
         {
             if (_webRequest!= null && !_webRequest.isDone)
@@ -123,7 +128,7 @@ namespace GooglePlayInstant.Editor
                 AddVerifyComponentInfo("AssetBundle Download Status:",
                     _assetBundleDownloadIsSuccessful ? "SUCCESS" : "FAILED");
 
-                AddVerifyComponentInfo("AssetBundle URL:", _assetBundleUrl);
+                AddVerifyComponentInfo("AssetBundle URL:", string.IsNullOrEmpty(_assetBundleUrl) ? "N/A" : _assetBundleUrl);
 
                 AddVerifyComponentInfo("HTTP Status Code:", _responseCode == 0 ? "N/A" : _responseCode.ToString());
 

--- a/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
@@ -96,7 +96,9 @@ namespace GooglePlayInstant.Editor
         private void Update()
         {
             if (_webRequest == null || !_webRequest.isDone)
+            {
                 return;
+            }
 
             // Performs download operation only once when webrequest is completed.
             GetAssetBundleInfoFromDownload();

--- a/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
@@ -100,18 +100,18 @@ namespace GooglePlayInstant.Editor
         //TODO: fix malformed url behavior
         private void Update()
         {
-            // Performs download operation only once when webrequest is completed.
-            if (_webRequest != null)
+            if (_webRequest == null)
+                return;
+            if (!_webRequest.isDone)
             {
-                if (!_webRequest.isDone)
-                {
-                    _isLoading = true;
-                }
-                else
-                {
-                    GetAssetBundleInfoFromDownload();
-                    Repaint();
-                }
+                _isLoading = true;
+            }
+            else
+            {
+                // Performs download operation only once when webrequest is completed.
+                GetAssetBundleInfoFromDownload();
+                Repaint();
+                _isLoading = false;
             }
         }
 
@@ -120,13 +120,12 @@ namespace GooglePlayInstant.Editor
         {
             if (_isLoading)
             {
-                if (progress < secs)
-                    EditorUtility.DisplayProgressBar("Simple Progress Bar", "Shows a progress bar for the given seconds", progress / secs);
-                else
-                    EditorUtility.ClearProgressBar();
+                EditorUtility.DisplayProgressBar("AssetBundle Download Progress Bar", "", _webRequest.downloadProgress);
             }
             else
             {  
+                EditorUtility.ClearProgressBar();
+                
                 AddVerifyComponentInfo("AssetBundle Download Status:",
                     _assetBundleDownloadIsSuccessful ? "SUCCESS" : "FAILED");
 

--- a/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
@@ -32,6 +32,7 @@ namespace GooglePlayInstant.Editor
         private string _mainScene;
         private double _numOfMegabytes;
         private UnityWebRequest _webRequest;
+        private bool _isLoading;
 
         /// <summary>
         /// Creates a dialog box that details the success or failure of an AssetBundle retrieval from a given assetBundleUrl.
@@ -100,33 +101,50 @@ namespace GooglePlayInstant.Editor
         private void Update()
         {
             // Performs download operation only once when webrequest is completed.
-            if ((_webRequest != null) && (_webRequest.isDone))
+            if (_webRequest != null)
             {
-                GetAssetBundleInfoFromDownload();
-                Repaint();
+                if (!_webRequest.isDone)
+                {
+                    _isLoading = true;
+                }
+                else
+                {
+                    GetAssetBundleInfoFromDownload();
+                    Repaint();
+                }
             }
         }
 
         //TODO: add a loading state so client knows that some loading is going on behind the scenes.
         private void OnGUI()
         {
-            AddVerifyComponentInfo("AssetBundle Download Status:",
-                _assetBundleDownloadIsSuccessful ? "SUCCESS" : "FAILED");
-
-            AddVerifyComponentInfo("AssetBundle URL:", _assetBundleUrl);
-
-            AddVerifyComponentInfo("HTTP Status Code:", _responseCode == 0 ? "N/A" : _responseCode.ToString());
-
-            AddVerifyComponentInfo("Error Description:", _assetBundleDownloadIsSuccessful ? "N/A" : _errorDescription);
-
-            AddVerifyComponentInfo("Main Scene:", _assetBundleDownloadIsSuccessful ? _mainScene : "N/A");
-
-            AddVerifyComponentInfo("Size (MB):",
-                _assetBundleDownloadIsSuccessful ? _numOfMegabytes.ToString("#.####") : "N/A");
-
-            if (GUILayout.Button("Refresh"))
+            if (_isLoading)
             {
-                StartAssetBundleVerificationDownload();
+                if (progress < secs)
+                    EditorUtility.DisplayProgressBar("Simple Progress Bar", "Shows a progress bar for the given seconds", progress / secs);
+                else
+                    EditorUtility.ClearProgressBar();
+            }
+            else
+            {  
+                AddVerifyComponentInfo("AssetBundle Download Status:",
+                    _assetBundleDownloadIsSuccessful ? "SUCCESS" : "FAILED");
+
+                AddVerifyComponentInfo("AssetBundle URL:", _assetBundleUrl);
+
+                AddVerifyComponentInfo("HTTP Status Code:", _responseCode == 0 ? "N/A" : _responseCode.ToString());
+
+                AddVerifyComponentInfo("Error Description:", _assetBundleDownloadIsSuccessful ? "N/A" : _errorDescription);
+
+                AddVerifyComponentInfo("Main Scene:", _assetBundleDownloadIsSuccessful ? _mainScene : "N/A");
+
+                AddVerifyComponentInfo("Size (MB):",
+                    _assetBundleDownloadIsSuccessful ? _numOfMegabytes.ToString("#.####") : "N/A");
+
+                if (GUILayout.Button("Refresh"))
+                {
+                    StartAssetBundleVerificationDownload();
+                }
             }
         }
 

--- a/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
@@ -32,7 +32,6 @@ namespace GooglePlayInstant.Editor
         private string _mainScene;
         private double _numOfMegabytes;
         private UnityWebRequest _webRequest;
-        private bool _isLoading;
 
         /// <summary>
         /// Creates a dialog box that details the success or failure of an AssetBundle retrieval from a given assetBundleUrl.
@@ -87,9 +86,6 @@ namespace GooglePlayInstant.Editor
                 // all objects that were loaded from this bundle.
                 bundle.Unload(true);
             }
-
-            // Turn request to null to be prepared for next call
-            _webRequest.Dispose();
         }
 
         private double ConvertBytesToMegabytes(ulong bytes)
@@ -100,27 +96,25 @@ namespace GooglePlayInstant.Editor
         //TODO: fix malformed url behavior
         private void Update()
         {
-            if (_webRequest == null)
+            if (_webRequest == null || !_webRequest.isDone)
                 return;
-            if (!_webRequest.isDone)
-            {
-                _isLoading = true;
-            }
-            else
-            {
-                // Performs download operation only once when webrequest is completed.
-                GetAssetBundleInfoFromDownload();
-                Repaint();
-                _isLoading = false;
-            }
+            
+            // Performs download operation only once when webrequest is completed.
+            GetAssetBundleInfoFromDownload();
+            Repaint();
+            
+            // Turn request to null to be prepared for next call
+            _webRequest.Dispose();
+            _webRequest = null;
         }
 
         //TODO: add a loading state so client knows that some loading is going on behind the scenes.
         private void OnGUI()
         {
-            if (_isLoading)
+            if (_webRequest!= null && !_webRequest.isDone)
             {
-                EditorUtility.DisplayProgressBar("AssetBundle Download Progress Bar", "", _webRequest.downloadProgress);
+                EditorUtility.DisplayProgressBar("AssetBundle Download Progress Bar", "",
+                    _webRequest.downloadProgress);
             }
             else
             {  

--- a/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
@@ -24,7 +24,7 @@ namespace GooglePlayInstant.Editor
     public class AssetBundleVerifierWindow : EditorWindow
     {
         private const int FieldMinWidth = 170;
-        
+
         private bool _assetBundleDownloadIsSuccessful;
         private string _assetBundleUrl;
         private long _responseCode;
@@ -57,6 +57,7 @@ namespace GooglePlayInstant.Editor
                 _errorDescription = "URL is null or empty.";
                 return;
             }
+
             _webRequest = UnityWebRequestAssetBundle.GetAssetBundle(_assetBundleUrl);
             _webRequest.SendWebRequest();
         }
@@ -104,11 +105,11 @@ namespace GooglePlayInstant.Editor
         {
             if (_webRequest == null || !_webRequest.isDone)
                 return;
-            
+
             // Performs download operation only once when webrequest is completed.
             GetAssetBundleInfoFromDownload();
             Repaint();
-            
+
             // Turn request to null to signal ready for next call
             _webRequest.Dispose();
             _webRequest = null;
@@ -116,23 +117,25 @@ namespace GooglePlayInstant.Editor
 
         private void OnGUI()
         {
-            if (_webRequest!= null && !_webRequest.isDone)
+            if (_webRequest != null && !_webRequest.isDone)
             {
                 EditorUtility.DisplayProgressBar("AssetBundle Download Progress Bar", "",
                     _webRequest.downloadProgress);
             }
             else
-            {  
+            {
                 EditorUtility.ClearProgressBar();
-                
+
                 AddVerifyComponentInfo("AssetBundle Download Status:",
                     _assetBundleDownloadIsSuccessful ? "SUCCESS" : "FAILED");
 
-                AddVerifyComponentInfo("AssetBundle URL:", string.IsNullOrEmpty(_assetBundleUrl) ? "N/A" : _assetBundleUrl);
+                AddVerifyComponentInfo("AssetBundle URL:",
+                    string.IsNullOrEmpty(_assetBundleUrl) ? "N/A" : _assetBundleUrl);
 
                 AddVerifyComponentInfo("HTTP Status Code:", _responseCode == 0 ? "N/A" : _responseCode.ToString());
 
-                AddVerifyComponentInfo("Error Description:", _assetBundleDownloadIsSuccessful ? "N/A" : _errorDescription);
+                AddVerifyComponentInfo("Error Description:",
+                    _assetBundleDownloadIsSuccessful ? "N/A" : _errorDescription);
 
                 AddVerifyComponentInfo("Main Scene:", _assetBundleDownloadIsSuccessful ? _mainScene : "N/A");
 

--- a/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
@@ -104,7 +104,9 @@ namespace GooglePlayInstant.Editor
         private void Update()
         {
             if (_webRequest == null || !_webRequest.isDone)
+            {
                 return;
+            }
 
             // Performs download operation only once when webrequest is completed.
             GetAssetBundleInfoFromDownload();
@@ -119,7 +121,7 @@ namespace GooglePlayInstant.Editor
         {
             if (_webRequest != null && !_webRequest.isDone)
             {
-                EditorUtility.DisplayProgressBar("AssetBundle Download Progress Bar", "",
+                EditorUtility.DisplayProgressBar("AssetBundle Download", "",
                     _webRequest.downloadProgress);
             }
             else

--- a/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/AssetBundleVerifierWindow.cs
@@ -50,14 +50,6 @@ namespace GooglePlayInstant.Editor
         //TODO: Support Unity 5.6.0+
         private void StartAssetBundleVerificationDownload()
         {
-            if (string.IsNullOrEmpty(_assetBundleUrl))
-            {
-                _assetBundleDownloadIsSuccessful = false;
-                Debug.Log("Problem retrieving AssetBundle: URL is null or empty.");
-                _errorDescription = "URL is null or empty.";
-                return;
-            }
-
             _webRequest = UnityWebRequestAssetBundle.GetAssetBundle(_assetBundleUrl);
             _webRequest.SendWebRequest();
         }
@@ -104,9 +96,7 @@ namespace GooglePlayInstant.Editor
         private void Update()
         {
             if (_webRequest == null || !_webRequest.isDone)
-            {
                 return;
-            }
 
             // Performs download operation only once when webrequest is completed.
             GetAssetBundleInfoFromDownload();

--- a/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/PlayInstantQuickDeployWindow.cs
@@ -168,7 +168,14 @@ namespace GooglePlayInstant.Editor
 
             if (GUILayout.Button("Verify AssetBundle", GUILayout.Width(ButtonWidth)))
             {
-                AssetBundleVerifierWindow.ShowWindow();
+                if (string.IsNullOrEmpty(QuickDeployConfig.Config.assetBundleUrl))
+                {
+                    Debug.LogError("AssetBundle URL text field cannot be empty.");
+                }
+                else
+                {
+                    AssetBundleVerifierWindow.ShowWindow();
+                }
             }
 
             EditorGUILayout.EndVertical();


### PR DESCRIPTION
Added a loading state so that the client knows that some loading is going on behind the scenes will their asset bundle is loading (especially if the asset bundle is large). 

Also mended the malformed URL behavior with the update method that printed out 900+ console messages if the URL was null or empty.

![image](https://user-images.githubusercontent.com/20508605/43220530-215c3470-8fff-11e8-85f5-e0a72fe4249f.png)
