### PR TITLE
Fixed loading bar crash during Asset Bundle verification

### DIFF
--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -93,30 +93,29 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             return bytes / 1024f / 1024f;
         }
 
-        // TODO: fix nested if statements
         private void Update()
         {
-            if (_webRequest == null || !_webRequest.isDone)
+            if (_webRequest == null)
             {
-                if (_webRequest != null && !_webRequest.isDone)
-                {
-                    if (EditorUtility.DisplayCancelableProgressBar("AssetBundle Download", "",
-                        _webRequest.downloadProgress))
-                    {
-                        _webRequest.Abort();
-                        _webRequest.Dispose();
-                        _webRequest = null;
+                return;
+            }
 
-                        Debug.Log("Download process was cancelled.");
-                    }
-                }
-                else
+            if (!_webRequest.isDone)
+            {
+                if (EditorUtility.DisplayCancelableProgressBar("AssetBundle Download", "",
+                    _webRequest.downloadProgress))
                 {
-                    EditorUtility.ClearProgressBar();
+                    _webRequest.Abort();
+                    _webRequest.Dispose();
+                    _webRequest = null;
+
+                    Debug.Log("Download process was cancelled.");
                 }
 
                 return;
             }
+
+            EditorUtility.ClearProgressBar();
 
             // Performs download operation only once when webrequest is completed.
             GetAssetBundleInfoFromDownload();

--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -97,6 +97,23 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         {
             if (_webRequest == null || !_webRequest.isDone)
             {
+                if (_webRequest != null && !_webRequest.isDone)
+                {
+                    if (EditorUtility.DisplayCancelableProgressBar("AssetBundle Download", "",
+                        _webRequest.downloadProgress))
+                    {
+                        _webRequest.Abort();
+                        _webRequest.Dispose();
+                        _webRequest = null;
+
+                        Debug.Log("Download process was cancelled.");
+                    }
+                }
+                else
+                {
+                    EditorUtility.ClearProgressBar();
+                }
+
                 return;
             }
 
@@ -112,35 +129,25 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         // TODO: fix crashing associated with using DisplayProgressBar()
         private void OnGUI()
         {
-            if (_webRequest != null && !_webRequest.isDone)
+            AddVerifyComponentInfo("AssetBundle Download Status:",
+                _assetBundleDownloadIsSuccessful ? "SUCCESS" : "FAILED");
+
+            AddVerifyComponentInfo("AssetBundle URL:",
+                string.IsNullOrEmpty(_assetBundleUrl) ? "N/A" : _assetBundleUrl);
+
+            AddVerifyComponentInfo("HTTP Status Code:", _responseCode == 0 ? "N/A" : _responseCode.ToString());
+
+            AddVerifyComponentInfo("Error Description:",
+                _assetBundleDownloadIsSuccessful ? "N/A" : _errorDescription);
+
+            AddVerifyComponentInfo("Main Scene:", _assetBundleDownloadIsSuccessful ? _mainScene : "N/A");
+
+            AddVerifyComponentInfo("Size (MB):",
+                _assetBundleDownloadIsSuccessful ? _numOfMegabytes.ToString("#.####") : "N/A");
+
+            if (GUILayout.Button("Refresh"))
             {
-                EditorUtility.DisplayProgressBar("AssetBundle Download", "",
-                    _webRequest.downloadProgress);
-            }
-            else
-            {
-                EditorUtility.ClearProgressBar();
-
-                AddVerifyComponentInfo("AssetBundle Download Status:",
-                    _assetBundleDownloadIsSuccessful ? "SUCCESS" : "FAILED");
-
-                AddVerifyComponentInfo("AssetBundle URL:",
-                    string.IsNullOrEmpty(_assetBundleUrl) ? "N/A" : _assetBundleUrl);
-
-                AddVerifyComponentInfo("HTTP Status Code:", _responseCode == 0 ? "N/A" : _responseCode.ToString());
-
-                AddVerifyComponentInfo("Error Description:",
-                    _assetBundleDownloadIsSuccessful ? "N/A" : _errorDescription);
-
-                AddVerifyComponentInfo("Main Scene:", _assetBundleDownloadIsSuccessful ? _mainScene : "N/A");
-
-                AddVerifyComponentInfo("Size (MB):",
-                    _assetBundleDownloadIsSuccessful ? _numOfMegabytes.ToString("#.####") : "N/A");
-
-                if (GUILayout.Button("Refresh"))
-                {
-                    StartAssetBundleVerificationDownload();
-                }
+                StartAssetBundleVerificationDownload();
             }
         }
 

--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -93,6 +93,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             return bytes / 1024f / 1024f;
         }
 
+        // TODO: fix nested if statements
         private void Update()
         {
             if (_webRequest == null || !_webRequest.isDone)

--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -126,7 +126,6 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             _webRequest = null;
         }
 
-        // TODO: fix crashing associated with using DisplayProgressBar()
         private void OnGUI()
         {
             AddVerifyComponentInfo("AssetBundle Download Status:",


### PR DESCRIPTION
Fixed a bug with the display progress bar that caused it to crash immediately when using it to verify the bundle. In addition, it is now cancelable, and can be used to stop the operation.