### PR TITLE
Added web request support for Unity 5.6 and higher and retry logic

### DIFF
--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -65,7 +65,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             _responseCode = _webRequest.responseCode;
 
 #if UNITY_2017_1_OR_NEWER
-            if (_webRequest.isHttpError || _webRequest.isNetworkError )
+            if (_webRequest.isHttpError || _webRequest.isNetworkError)
 #else
             if (_webRequest.isError)
 #endif
@@ -116,7 +116,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             _webRequest = null;
         }
 
-        // TODO: fix crashing associated with using DisplayProgressBar() and revist after merging with fix branch
+        // TODO: fix crashing associated with using DisplayProgressBar() and revist after merging with fix branchø
         private void OnGUI()
         {
             if (_webRequest != null && !_webRequest.isDone)

--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -47,14 +47,17 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             window.StartAssetBundleVerificationDownload();
         }
 
-        //TODO: Support Unity 5.6.0+
         private void StartAssetBundleVerificationDownload()
         {
+#if UNITY_2018_1_OR_NEWER
             _webRequest = UnityWebRequestAssetBundle.GetAssetBundle(_assetBundleUrl);
             _webRequest.SendWebRequest();
+#else
+            _webRequest = UnityWebRequest.GetAssetBundle(assetBundleUrl);
+            _webRequest.Send();
+#endif
         }
 
-        //TODO: Support Unity 5.6.0+
         private void GetAssetBundleInfoFromDownload()
         {
             var bundle = DownloadHandlerAssetBundle.GetContent(_webRequest);

--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -52,6 +52,9 @@ namespace GooglePlayInstant.Editor.QuickDeploy
 #if UNITY_2018_1_OR_NEWER
             _webRequest = UnityWebRequestAssetBundle.GetAssetBundle(_assetBundleUrl);
             _webRequest.SendWebRequest();
+#elif UNITY_2017_1_OR_NEWER
+            _webRequest = UnityWebRequest.GetAssetBundle(_assetBundleUrl);
+            _webRequest.SendWebRequest();
 #else
             _webRequest = UnityWebRequest.GetAssetBundle(_assetBundleUrl);
             _webRequest.Send();
@@ -95,7 +98,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             }
         }
 
-        private double ConvertBytesToMegabytes(ulong bytes)
+        private static double ConvertBytesToMegabytes(ulong bytes)
         {
             return bytes / 1024f / 1024f;
         }
@@ -151,7 +154,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             }
         }
 
-        private void AddVerifyComponentInfo(string title, string response)
+        private static void AddVerifyComponentInfo(string title, string response)
         {
             EditorGUILayout.BeginHorizontal();
             EditorGUILayout.LabelField(title, GUILayout.MinWidth(FieldMinWidth));

--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -112,7 +112,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             _webRequest = null;
         }
 
-        // TODO: fix crashing associated with using DisplayProgressBar()
+        // TODO: fix crashing associated with using DisplayProgressBar() and revist after merging with fix branch
         private void OnGUI()
         {
             if (_webRequest != null && !_webRequest.isDone)

--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -116,7 +116,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             _webRequest = null;
         }
 
-        // TODO: fix crashing associated with using DisplayProgressBar() and revist after merging with fix branchø
+        // TODO: fix crashing associated with using DisplayProgressBar() and revist after merging with fix branch
         private void OnGUI()
         {
             if (_webRequest != null && !_webRequest.isDone)

--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -64,7 +64,11 @@ namespace GooglePlayInstant.Editor.QuickDeploy
 
             _responseCode = _webRequest.responseCode;
 
-            if (_webRequest.isNetworkError || _webRequest.isHttpError)
+#if UNITY_2017_1_OR_NEWER
+            if (_webRequest.isHttpError || _webRequest.isNetworkError )
+#else
+            if (_webRequest.isError)
+#endif
             {
                 _assetBundleDownloadIsSuccessful = false;
                 _errorDescription = _webRequest.error;

--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -53,7 +53,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             _webRequest = UnityWebRequestAssetBundle.GetAssetBundle(_assetBundleUrl);
             _webRequest.SendWebRequest();
 #else
-            _webRequest = UnityWebRequest.GetAssetBundle(assetBundleUrl);
+            _webRequest = UnityWebRequest.GetAssetBundle(_assetBundleUrl);
             _webRequest.Send();
 #endif
         }

--- a/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
@@ -41,7 +41,6 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         /// </summary>
         public static string LoadingScreenImagePath { get; set; }
 
-        //TODO: fix wasteful sprite creation by deleting previous unused ones
         /// <summary>
         /// Creates a scene in the current project that acts as a loading scene until assetbundles are
         /// downloaded from the CDN. Takes in a loadingScreenImagePath, a path to the image shown in the loading scene,

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -65,12 +65,17 @@ namespace GooglePlayInstant.LoadingScreen
             var webRequest = UnityWebRequest.GetAssetBundle(assetBundleUrl);
             var assetbundleDownloadOperation = webRequest.Send();
 #endif
-
+            
+            
             yield return StartCoroutine(LoadingBar.UpdateLoadingBar(assetbundleDownloadOperation,
                 LoadingBar.AssetBundleDownloadMaxWidthPercentage));
 
             // TODO: implement retry logic
-            if (webRequest.isNetworkError || webRequest.isHttpError)
+#if UNITY_2017_1_OR_NEWER
+            if (webRequest.isHttpError || webRequest.isNetworkError )
+#else
+            if (webRequest.isError)
+#endif
             {
                 Debug.LogErrorFormat("Error downloading asset bundle: {0}", webRequest.error);
             }

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -56,27 +56,27 @@ namespace GooglePlayInstant.LoadingScreen
             }
         }
 
-        //TODO: Update function for unity 5.6 functionality
         private IEnumerator GetAssetBundle(string assetBundleUrl)
         {
-#if UNITY_2018_2_OR_NEWER
-            var www = UnityWebRequestAssetBundle.GetAssetBundle(assetBundleUrl);
+#if UNITY_2018_1_OR_NEWER
+            var webRequest = UnityWebRequestAssetBundle.GetAssetBundle(assetBundleUrl);
+            var assetbundleDownloadOperation = webRequest.SendWebRequest();
 #else
-            var www = UnityWebRequest.GetAssetBundle(assetBundleUrl);
+            var webRequest = UnityWebRequest.GetAssetBundle(assetBundleUrl);
+            var assetbundleDownloadOperation = webRequest.Send();
 #endif
-            var assetbundleDownloadOperation = www.SendWebRequest();
 
             yield return StartCoroutine(LoadingBar.UpdateLoadingBar(assetbundleDownloadOperation,
                 LoadingBar.AssetBundleDownloadMaxWidthPercentage));
 
             // TODO: implement retry logic
-            if (www.isNetworkError || www.isHttpError)
+            if (webRequest.isNetworkError || webRequest.isHttpError)
             {
-                Debug.LogErrorFormat("Error downloading asset bundle: {0}", www.error);
+                Debug.LogErrorFormat("Error downloading asset bundle: {0}", webRequest.error);
             }
             else
             {
-                _bundle = DownloadHandlerAssetBundle.GetContent(www);
+                _bundle = DownloadHandlerAssetBundle.GetContent(webRequest);
             }
         }
     }

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -65,14 +65,12 @@ namespace GooglePlayInstant.LoadingScreen
             var webRequest = UnityWebRequest.GetAssetBundle(assetBundleUrl);
             var assetbundleDownloadOperation = webRequest.Send();
 #endif
-            
-            
             yield return StartCoroutine(LoadingBar.UpdateLoadingBar(assetbundleDownloadOperation,
                 LoadingBar.AssetBundleDownloadMaxWidthPercentage));
 
             // TODO: implement retry logic
 #if UNITY_2017_1_OR_NEWER
-            if (webRequest.isHttpError || webRequest.isNetworkError )
+            if (webRequest.isHttpError || webRequest.isNetworkError)
 #else
             if (webRequest.isError)
 #endif

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -54,8 +54,7 @@ namespace GooglePlayInstant.LoadingScreen
             else
             {
                 var sceneLoadOperation = SceneManager.LoadSceneAsync(_bundle.GetAllScenePaths()[0]);
-                yield return LoadingBar.UpdateLoadingBar(sceneLoadOperation,
-                    LoadingBar.SceneLoadingMaxWidthPercentage);
+                yield return LoadingBar.UpdateLoadingBar(sceneLoadOperation, LoadingBar.SceneLoadingMaxWidthPercentage);
             }
         }
 

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -54,8 +54,8 @@ namespace GooglePlayInstant.LoadingScreen
             else
             {
                 var sceneLoadOperation = SceneManager.LoadSceneAsync(_bundle.GetAllScenePaths()[0]);
-                yield return StartCoroutine(LoadingBar.UpdateLoadingBar(sceneLoadOperation,
-                    LoadingBar.SceneLoadingMaxWidthPercentage));
+                yield return LoadingBar.UpdateLoadingBar(sceneLoadOperation,
+                    LoadingBar.SceneLoadingMaxWidthPercentage);
             }
         }
 
@@ -64,12 +64,15 @@ namespace GooglePlayInstant.LoadingScreen
 #if UNITY_2018_1_OR_NEWER
             var webRequest = UnityWebRequestAssetBundle.GetAssetBundle(assetBundleUrl);
             var assetbundleDownloadOperation = webRequest.SendWebRequest();
+#elif UNITY_2017_1_OR_NEWER
+            var webRequest = UnityWebRequest.GetAssetBundle(assetBundleUrl);
+            var assetbundleDownloadOperation = webRequest.SendWebRequest();
 #else
             var webRequest = UnityWebRequest.GetAssetBundle(assetBundleUrl);
             var assetbundleDownloadOperation = webRequest.Send();
 #endif
-            yield return StartCoroutine(LoadingBar.UpdateLoadingBar(assetbundleDownloadOperation,
-                LoadingBar.AssetBundleDownloadMaxWidthPercentage));
+            yield return LoadingBar.UpdateLoadingBar(assetbundleDownloadOperation,
+                LoadingBar.AssetBundleDownloadMaxWidthPercentage);
 
 #if UNITY_2017_1_OR_NEWER
             if (webRequest.isHttpError || webRequest.isNetworkError)


### PR DESCRIPTION
Included directives that made it possible to retrieve asset bundles from 5.6 and higher. Documentation from 5.6 for reference:

https://docs.unity3d.com/560/Documentation/Manual/UnityWebRequest-DownloadingAssetBundle.html

Also features retry logic for getting AssetBundles off the specified URL.
