### PR TITLE
Positioning the loading bar during runtime

### DIFF
--- a/GooglePlayInstant/Editor/GooglePlayServices/CommandLine.cs
+++ b/GooglePlayInstant/Editor/GooglePlayServices/CommandLine.cs
@@ -670,6 +670,14 @@ namespace GooglePlayInstant.Editor.GooglePlayServices
                 toolPath, arguments, stdout, stderr, exitCode);
         }
 
+        /// <summary>
+        /// Returns the specified argument in double quotes if it contains at least one space, otherwise returns as is.
+        /// </summary>
+        public static string QuotePathIfNecessary(string path)
+        {
+            return path.Contains(" ") ? string.Format("\"{0}\"", path) : path;
+        }
+
 #if UNITY_EDITOR
         /// <summary>
         /// Get an executable extension.

--- a/GooglePlayInstant/Editor/PlayInstantBuildConfiguration.cs
+++ b/GooglePlayInstant/Editor/PlayInstantBuildConfiguration.cs
@@ -50,39 +50,40 @@ namespace GooglePlayInstant.Editor
         /// <summary>
         /// Optional field used to prevent removal of required components when building with engine stripping.
         /// <see cref="https://docs.unity3d.com/ScriptReference/BuildPlayerOptions-assetBundleManifestPath.html"/>
+        /// Never null.
         /// </summary>
         public static string AssetBundleManifestPath
         {
             get
             {
                 LoadConfigIfNecessary();
-                return _config.assetBundleManifestPath;
+                return _config.assetBundleManifestPath ?? string.Empty;
             }
         }
 
         /// <summary>
         /// Optional URL that can be used to launch this instant app. If empty, the app will be "URL-less" and
-        /// use an automatically created URL, e.g. https://instant.apps/package-name.
+        /// use an automatically created URL, e.g. https://instant.apps/package-name. Never null.
         /// </summary>
         public static string InstantUrl
         {
             get
             {
                 LoadConfigIfNecessary();
-                return _config.instantUrl;
+                return _config.instantUrl ?? string.Empty;
             }
         }
 
         /// <summary>
         /// Optional array of scenes to include in the build. If not specified, the enabled scenes from the
-        /// Unity "Build Settings" window will be used.
+        /// Unity "Build Settings" window will be used. Never null.
         /// </summary>
         public static string[] ScenesInBuild
         {
             get
             {
                 LoadConfigIfNecessary();
-                return _config.scenesInBuild;
+                return _config.scenesInBuild ?? new string[0];
             }
         }
 

--- a/GooglePlayInstant/Editor/PlayInstantBuilder.cs
+++ b/GooglePlayInstant/Editor/PlayInstantBuilder.cs
@@ -49,7 +49,7 @@ namespace GooglePlayInstant.Editor
         public static BuildPlayerOptions CreateBuildPlayerOptions(string apkPath, BuildOptions options)
         {
             var scenesInBuild = PlayInstantBuildConfiguration.ScenesInBuild;
-            if (scenesInBuild == null || scenesInBuild.Length == 0)
+            if (scenesInBuild.Length == 0)
             {
                 scenesInBuild = GetEditorBuildEnabledScenes();
             }

--- a/GooglePlayInstant/Editor/PlayInstantPublisher.cs
+++ b/GooglePlayInstant/Editor/PlayInstantPublisher.cs
@@ -49,7 +49,11 @@ namespace GooglePlayInstant.Editor
             }
 
             // Zip creation is fast enough so call jar synchronously rather than wait for post build AppDomain reset.
-            var arguments = string.Format("cvf {0} -C {1} {2}", zipFilePath, baseApkDirectory, BaseApkFileName);
+            var arguments = string.Format(
+                "cvf {0} -C {1} {2}",
+                CommandLine.QuotePathIfNecessary(zipFilePath),
+                CommandLine.QuotePathIfNecessary(baseApkDirectory),
+                BaseApkFileName);
             var result = CommandLine.Run(JavaUtilities.JarBinaryPath, arguments);
             if (result.exitCode == 0)
             {

--- a/GooglePlayInstant/Editor/PlayInstantRunner.cs
+++ b/GooglePlayInstant/Editor/PlayInstantRunner.cs
@@ -63,10 +63,13 @@ namespace GooglePlayInstant.Editor
             window.summaryText = "Installing app on device";
             window.bodyText = "The APK built successfully. Waiting for scripts to reload...\n";
             window.autoScrollToBottom = true;
-            window.CommandLineParams = new CommandLineParameters()
+            window.CommandLineParams = new CommandLineParameters
             {
                 FileName = JavaUtilities.JavaBinaryPath,
-                Arguments = string.Format("-jar {0} run {1}", jarPath, apkPath)
+                Arguments = string.Format(
+                    "-jar {0} run {1}",
+                    CommandLine.QuotePathIfNecessary(jarPath),
+                    CommandLine.QuotePathIfNecessary(apkPath))
             };
             window.CommandLineParams.AddEnvironmentVariable(
                 AndroidSdkManager.AndroidHome, AndroidSdkManager.AndroidSdkRoot);

--- a/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
@@ -29,7 +29,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
     {
         public const string LoadingSceneName = "play-instant-loading-screen-scene";
 
-        public const string PlayInstantCanvasName = "PlayInstantCanvas";
+        private const string PlayInstantCanvasName = "Play Instant Canvas";
 
         private const string LoadingScreenJsonFileName = "LoadingScreenConfig.json";
 

--- a/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
@@ -29,6 +29,8 @@ namespace GooglePlayInstant.Editor.QuickDeploy
     {
         public const string LoadingSceneName = "play-instant-loading-screen-scene";
 
+        public const string PlayInstantCanvasName = "PlayInstantCanvas";
+
         private const string LoadingScreenJsonFileName = "LoadingScreenConfig.json";
 
         private static readonly string LoadingScreenScenePath =
@@ -62,7 +64,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             GenerateLoadingScreenConfigFile(assetBundleUrl);
 
             var loadingScreenScene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Additive);
-            var loadingScreenGameObject = new GameObject("Canvas");
+            var loadingScreenGameObject = new GameObject(PlayInstantCanvasName);
 
             AddLoadingScreenImageToScene(loadingScreenGameObject, LoadingScreenImagePath);
             AddLoadingScreenScript(loadingScreenGameObject);

--- a/GooglePlayInstant/LoadingScreen/LoadingBar.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingBar.cs
@@ -42,10 +42,10 @@ namespace GooglePlayInstant.LoadingScreen
         private const int LoadingBarHeight = 30;
 
         // Loading bar width as a percentage canvas object's automatic size
-        private const float LoadingBarWidthPercentage = .5f;
+        private const float LoadingBarWidthPercentage = .7f;
 
-        // Loading bar y axis placement as a percentage of canvas object's automatic y value
-        private const float LoadingBarYAxisPercentage = 2f;
+        // Loading bar y axis placement as a percentage of the screen height. 
+        private const float LoadingBarYAxisPercentage = .3f;
 
         // Names for the gameobject components
         private const string LoadingBarGameObjectName = "Loading Bar";
@@ -53,7 +53,6 @@ namespace GooglePlayInstant.LoadingScreen
         private const string LoadingBarFillGameObjectName = "Loading Bar Fill";
 
 #if UNITY_EDITOR
-        // TODO: fix persistance of loading bar
         /// <summary>
         /// Creates a loading bar component on the specified loading screen game object's bottom half. Consists of
         /// a white rounded border, with a colored loading bar fill in the middle.
@@ -63,22 +62,6 @@ namespace GooglePlayInstant.LoadingScreen
             var loadingBarGameObject = new GameObject(LoadingBarGameObjectName);
             loadingBarGameObject.AddComponent<RectTransform>();
             loadingBarGameObject.transform.SetParent(loadingScreenGameObject.transform);
-
-            var loadingBarRectTransform = loadingBarGameObject.GetComponent<RectTransform>();
-
-            var loadingScreenRectTransform = loadingScreenGameObject.GetComponent<RectTransform>();
-
-            // Set the size of the loading bar. LoadingBarWidthPercentage gives loading bar padding from the edges
-            // of the viewing device
-            loadingBarRectTransform.sizeDelta =
-                new Vector2(loadingScreenRectTransform.sizeDelta.x * LoadingBarWidthPercentage,
-                    LoadingBarHeight);
-
-            // Set the position of the loading bar
-            loadingBarRectTransform.position =
-                new Vector2(loadingScreenRectTransform.position.x,
-                    loadingScreenRectTransform.position.y -
-                    LoadingBarYAxisPercentage * loadingScreenRectTransform.position.y);
 
             SetLoadingBarOutline(loadingBarGameObject);
             SetLoadingBarFill(loadingBarGameObject);
@@ -130,10 +113,57 @@ namespace GooglePlayInstant.LoadingScreen
 #endif
 
         /// <summary>
+        /// Sets the position of the loading bar as a function of the screen height and LoadingBarYAxisPercentage constant.
+        /// </summary>
+        public static void SetPosition()
+        {
+            var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
+
+            loadingBarRectTransform.position = new Vector2(Screen.width / 2f, Screen.height * LoadingBarYAxisPercentage);
+        }
+
+        /// <summary>
+        /// Sets the length of the loading bar and its children as a function of the screen width and LoadingBarWidthPercentage constant.
+        /// </summary>
+        public static void SetWidth()
+        {
+            var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
+            var loadingBarFillRectTransform =
+                GameObject.Find(LoadingBarFillGameObjectName).GetComponent<RectTransform>();
+            var loadingBarOutlineRectTransform =
+                GameObject.Find(LoadingBarOutlineGameObjectName).GetComponent<RectTransform>();
+
+
+            loadingBarRectTransform.sizeDelta =
+                new Vector2(Screen.width * LoadingBarWidthPercentage,
+                    LoadingBarHeight);
+
+            loadingBarOutlineRectTransform.sizeDelta =
+                new Vector2(loadingBarRectTransform.sizeDelta.x,
+                    loadingBarRectTransform.sizeDelta.y);
+
+            loadingBarFillRectTransform.sizeDelta =
+                new Vector2(0, loadingBarRectTransform.sizeDelta.y - LoadingBarFillPadding);
+        }
+
+        /// <summary>
+        /// Resets the loading bar back to 0 percent.
+        /// </summary>
+        public static void Reset()
+        {
+            var loadingBarFillRectTransform =
+                GameObject.Find(LoadingBarFillGameObjectName).GetComponent<RectTransform>();
+
+            loadingBarFillRectTransform.sizeDelta =
+                new Vector2(0, loadingBarFillRectTransform.sizeDelta.y);
+        }
+
+
+        /// <summary>
         /// Updates a loading bar by the progress made by an asynchronous operation up to a specific percentage of
         /// the loading bar. 
         /// </summary>
-        public static IEnumerator UpdateLoadingBar(AsyncOperation operation, float percentageOfLoadingBar)
+        public static IEnumerator Update(AsyncOperation operation, float percentageOfLoadingBar)
         {
             var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
 

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -33,6 +33,8 @@ namespace GooglePlayInstant.LoadingScreen
 
         private IEnumerator Start()
         {
+//            Screen.orientation = ScreenOrientation.Portrait;
+
             var loadingScreenConfigJsonTextAsset =
                 Resources.Load<TextAsset>("LoadingScreenConfig");
 
@@ -54,12 +56,13 @@ namespace GooglePlayInstant.LoadingScreen
             else
             {
                 var sceneLoadOperation = SceneManager.LoadSceneAsync(_bundle.GetAllScenePaths()[0]);
-                yield return LoadingBar.UpdateLoadingBar(sceneLoadOperation, LoadingBar.SceneLoadingMaxWidthPercentage);
+
+                yield return LoadingBar.Update(sceneLoadOperation, LoadingBar.SceneLoadingMaxWidthPercentage);
             }
         }
 
         private IEnumerator GetAssetBundle(string assetBundleUrl)
-        {
+        {   
 #if UNITY_2018_1_OR_NEWER
             var webRequest = UnityWebRequestAssetBundle.GetAssetBundle(assetBundleUrl);
             var assetbundleDownloadOperation = webRequest.SendWebRequest();
@@ -70,7 +73,11 @@ namespace GooglePlayInstant.LoadingScreen
             var webRequest = UnityWebRequest.GetAssetBundle(assetBundleUrl);
             var assetbundleDownloadOperation = webRequest.Send();
 #endif
-            yield return LoadingBar.UpdateLoadingBar(assetbundleDownloadOperation,
+            LoadingBar.SetPosition();
+            LoadingBar.SetWidth();
+            
+
+            yield return LoadingBar.Update(assetbundleDownloadOperation,
                 LoadingBar.AssetBundleDownloadMaxWidthPercentage);
 
 #if UNITY_2017_1_OR_NEWER
@@ -84,6 +91,9 @@ namespace GooglePlayInstant.LoadingScreen
                     _assetBundleRetrievalAttemptCount++;
                     Debug.LogFormat("Attempt #{0} at downloading AssetBundle...", _assetBundleRetrievalAttemptCount);
                     yield return new WaitForSeconds(2);
+
+                    LoadingBar.Reset();
+
                     yield return GetAssetBundle(assetBundleUrl);
                 }
                 else

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -33,8 +33,6 @@ namespace GooglePlayInstant.LoadingScreen
 
         private IEnumerator Start()
         {
-//            Screen.orientation = ScreenOrientation.Portrait;
-
             var loadingScreenConfigJsonTextAsset =
                 Resources.Load<TextAsset>("LoadingScreenConfig");
 


### PR DESCRIPTION
This is a followup of the offline conversation we had, implemented. Currently, there exists one issue with this set up, and it's related to the retry logic in a previous PR. It's in this exact case:

-The loading bar takes an AsynOperation and begins to show the progress of downloading the AssetBundle.
-The user has a network issue.
-The loading bar stops it's progress. And then there is a reattempt to download the AssetBundle.
NOTE: The loading bar is code that is a function of a given (arbitrarily) chosen percentage and an operation. It cumulatively adds to the percentage already there.
-Since the loading bar is filled already with progress made on the AssetBundle prior to the network issue, retrying the connection would cause the loading bar to extend farther than the given outline. 

The current fix is an added Reset() function. Before another retry option is attempted, Reset() is called. 