### PR TITLE
Positioning the loading bar during runtime

### DIFF
--- a/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
@@ -29,7 +29,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
     {
         public const string LoadingSceneName = "play-instant-loading-screen-scene";
 
-        public const string PlayInstantCanvasName = "PlayInstantCanvas";
+        private const string PlayInstantCanvasName = "Play Instant Canvas";
 
         private const string LoadingScreenJsonFileName = "LoadingScreenConfig.json";
 

--- a/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
@@ -29,6 +29,8 @@ namespace GooglePlayInstant.Editor.QuickDeploy
     {
         public const string LoadingSceneName = "play-instant-loading-screen-scene";
 
+        public const string PlayInstantCanvasName = "PlayInstantCanvas";
+
         private const string LoadingScreenJsonFileName = "LoadingScreenConfig.json";
 
         private static readonly string LoadingScreenScenePath =
@@ -62,7 +64,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             GenerateLoadingScreenConfigFile(assetBundleUrl);
 
             var loadingScreenScene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Additive);
-            var loadingScreenGameObject = new GameObject("Canvas");
+            var loadingScreenGameObject = new GameObject(PlayInstantCanvasName);
 
             AddLoadingScreenImageToScene(loadingScreenGameObject, LoadingScreenImagePath);
             AddLoadingScreenScript(loadingScreenGameObject);

--- a/GooglePlayInstant/LoadingScreen/LoadingBar.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingBar.cs
@@ -39,13 +39,13 @@ namespace GooglePlayInstant.LoadingScreen
         // Loading bar fill's padding against the loading bar outline.
         private const int LoadingBarFillPadding = 17;
 
-        private const int LoadingBarHeight = 30;
+        // Loading bar size as a proportion of the screen size. Adjust if needed.
+        private const float LoadingBarWidthProportion = 0.7f;
+        private const float LoadingBarHeightProportion = 0.1f;
 
-        // Loading bar width as a percentage of the screen width.
-        private const float LoadingBarWidthPercentage = .7f;
-
-        // Loading bar y axis placement as a percentage of the screen height. 
-        private const float LoadingBarYAxisPercentage = .3f;
+        // Loading bar placement as a proportion of the screen size relative to the bottom left corner. Adjust if needed.
+        private const float LoadingBarPositionX = 0.5f;
+        private const float LoadingBarPositionY = 0.3f;
 
         // Names for the gameobject components
         private const string LoadingBarGameObjectName = "Loading Bar";
@@ -100,21 +100,7 @@ namespace GooglePlayInstant.LoadingScreen
         }
 #endif
 
-        /// <summary>
-        /// Sets the position of the loading bar as a function of the screen height and LoadingBarYAxisPercentage constant.
-        /// </summary>
-        public static void SetPosition()
-        {
-            var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
-
-            loadingBarRectTransform.position =
-                new Vector2(Screen.width / 2f, Screen.height * LoadingBarYAxisPercentage);
-        }
-
-        /// <summary>
-        /// Sets the length of the loading bar and its children as a function of the screen width and LoadingBarWidthPercentage constant.
-        /// </summary>
-        public static void SetWidth()
+        public static void UpdateSizeAndPostition()
         {
             var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
             var loadingBarFillRectTransform =
@@ -122,13 +108,43 @@ namespace GooglePlayInstant.LoadingScreen
             var loadingBarOutlineRectTransform =
                 GameObject.Find(LoadingBarOutlineGameObjectName).GetComponent<RectTransform>();
 
-            loadingBarRectTransform.sizeDelta =
-                new Vector2(Screen.width * LoadingBarWidthPercentage,
-                    LoadingBarHeight);
+            loadingBarRectTransform.position =
+                new Vector2(Screen.width * LoadingBarPositionX, Screen.height * LoadingBarPositionY);
 
-            loadingBarOutlineRectTransform.sizeDelta =
-                new Vector2(loadingBarRectTransform.sizeDelta.x,
-                    loadingBarRectTransform.sizeDelta.y);
+            loadingBarRectTransform.sizeDelta = new Vector2(Screen.width * LoadingBarWidthProportion,
+                Screen.height * LoadingBarHeightProportion);
+
+            loadingBarOutlineRectTransform.sizeDelta = loadingBarRectTransform.sizeDelta;
+            loadingBarFillRectTransform.sizeDelta =
+                new Vector2(0, loadingBarRectTransform.sizeDelta.y - LoadingBarFillPadding);
+        }
+
+        /// <summary>
+        /// Sets the position of the loading bar as a function of the screen height.
+        /// </summary>
+        public static void SetPosition()
+        {
+            var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
+
+            loadingBarRectTransform.position =
+                new Vector2(Screen.width * LoadingBarPositionX, Screen.height * LoadingBarPositionY);
+        }
+
+        /// <summary>
+        /// Sets the length of the loading bar and its children as a function of the screen width.
+        /// </summary>
+        public static void SetSize()
+        {
+            var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
+            var loadingBarFillRectTransform =
+                GameObject.Find(LoadingBarFillGameObjectName).GetComponent<RectTransform>();
+            var loadingBarOutlineRectTransform =
+                GameObject.Find(LoadingBarOutlineGameObjectName).GetComponent<RectTransform>();
+
+            loadingBarRectTransform.sizeDelta = new Vector2(Screen.width * LoadingBarWidthProportion,
+                Screen.height * LoadingBarHeightProportion);
+
+            loadingBarOutlineRectTransform.sizeDelta = loadingBarRectTransform.sizeDelta;
 
             loadingBarFillRectTransform.sizeDelta =
                 new Vector2(0, loadingBarRectTransform.sizeDelta.y - LoadingBarFillPadding);

--- a/GooglePlayInstant/LoadingScreen/LoadingBar.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingBar.cs
@@ -41,7 +41,7 @@ namespace GooglePlayInstant.LoadingScreen
 
         private const int LoadingBarHeight = 30;
 
-        // Loading bar width as a percentage screen width.
+        // Loading bar width as a percentage of the screen width.
         private const float LoadingBarWidthPercentage = .7f;
 
         // Loading bar y axis placement as a percentage of the screen height. 

--- a/GooglePlayInstant/LoadingScreen/LoadingBar.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingBar.cs
@@ -82,11 +82,6 @@ namespace GooglePlayInstant.LoadingScreen
             loadingBarOutlineImage.type = Image.Type.Sliced;
             loadingBarOutlineImage.fillCenter = false;
 
-            // Set size of component
-            var loadingBarOutlineRectTransform = loadingBarOutlineGameObject.GetComponent<RectTransform>();
-            var loadingBarRectTransform = loadingBarGameObject.GetComponent<RectTransform>();
-            loadingBarOutlineRectTransform.sizeDelta = loadingBarRectTransform.sizeDelta;
-
             // Position outline component
             loadingBarOutlineGameObject.transform.position = loadingBarGameObject.transform.position;
         }
@@ -99,13 +94,6 @@ namespace GooglePlayInstant.LoadingScreen
             loadingBarFillGameObject.AddComponent<Image>();
             var loadingBarFillImage = loadingBarFillGameObject.GetComponent<Image>();
             loadingBarFillImage.color = Color.green;
-
-            // Set size of component
-            var loadingBarFillRectTransform = loadingBarFillGameObject.GetComponent<RectTransform>();
-
-            var loadingBarRectTransform = loadingBarGameObject.GetComponent<RectTransform>();
-            loadingBarFillRectTransform.sizeDelta = new Vector2(0,
-                loadingBarRectTransform.sizeDelta.y - LoadingBarFillPadding);
 
             // Position fill component
             loadingBarFillGameObject.transform.position = loadingBarGameObject.transform.position;

--- a/GooglePlayInstant/LoadingScreen/LoadingBar.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingBar.cs
@@ -41,7 +41,7 @@ namespace GooglePlayInstant.LoadingScreen
 
         private const int LoadingBarHeight = 30;
 
-        // Loading bar width as a percentage canvas object's automatic size
+        // Loading bar width as a percentage screen width.
         private const float LoadingBarWidthPercentage = .7f;
 
         // Loading bar y axis placement as a percentage of the screen height. 

--- a/GooglePlayInstant/LoadingScreen/LoadingBar.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingBar.cs
@@ -42,10 +42,10 @@ namespace GooglePlayInstant.LoadingScreen
         private const int LoadingBarHeight = 30;
 
         // Loading bar width as a percentage canvas object's automatic size
-        private const float LoadingBarWidthPercentage = .5f;
+        private const float LoadingBarWidthPercentage = .7f;
 
-        // Loading bar y axis placement as a percentage of canvas object's automatic y value
-        private const float LoadingBarYAxisPercentage = 2f;
+        // Loading bar y axis placement as a percentage of the screen height. 
+        private const float LoadingBarYAxisPercentage = .3f;
 
         // Names for the gameobject components
         private const string LoadingBarGameObjectName = "Loading Bar";
@@ -53,7 +53,6 @@ namespace GooglePlayInstant.LoadingScreen
         private const string LoadingBarFillGameObjectName = "Loading Bar Fill";
 
 #if UNITY_EDITOR
-        // TODO: fix persistance of loading bar
         /// <summary>
         /// Creates a loading bar component on the specified loading screen game object's bottom half. Consists of
         /// a white rounded border, with a colored loading bar fill in the middle.
@@ -63,22 +62,6 @@ namespace GooglePlayInstant.LoadingScreen
             var loadingBarGameObject = new GameObject(LoadingBarGameObjectName);
             loadingBarGameObject.AddComponent<RectTransform>();
             loadingBarGameObject.transform.SetParent(loadingScreenGameObject.transform);
-
-            var loadingBarRectTransform = loadingBarGameObject.GetComponent<RectTransform>();
-
-            var loadingScreenRectTransform = loadingScreenGameObject.GetComponent<RectTransform>();
-
-            // Set the size of the loading bar. LoadingBarWidthPercentage gives loading bar padding from the edges
-            // of the viewing device
-            loadingBarRectTransform.sizeDelta =
-                new Vector2(loadingScreenRectTransform.sizeDelta.x * LoadingBarWidthPercentage,
-                    LoadingBarHeight);
-
-            // Set the position of the loading bar
-            loadingBarRectTransform.position =
-                new Vector2(loadingScreenRectTransform.position.x,
-                    loadingScreenRectTransform.position.y -
-                    LoadingBarYAxisPercentage * loadingScreenRectTransform.position.y);
 
             SetLoadingBarOutline(loadingBarGameObject);
             SetLoadingBarFill(loadingBarGameObject);
@@ -130,10 +113,57 @@ namespace GooglePlayInstant.LoadingScreen
 #endif
 
         /// <summary>
+        /// Sets the position of the loading bar as a function of the screen height and LoadingBarYAxisPercentage constant.
+        /// </summary>
+        public static void SetPosition()
+        {
+            var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
+
+            loadingBarRectTransform.position = new Vector2(Screen.width / 2f, Screen.height * LoadingBarYAxisPercentage);
+        }
+
+        /// <summary>
+        /// Sets the length of the loading bar and its children as a function of the screen width and LoadingBarWidthPercentage constant.
+        /// </summary>
+        public static void SetWidth()
+        {
+            var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
+            var loadingBarFillRectTransform =
+                GameObject.Find(LoadingBarFillGameObjectName).GetComponent<RectTransform>();
+            var loadingBarOutlineRectTransform =
+                GameObject.Find(LoadingBarOutlineGameObjectName).GetComponent<RectTransform>();
+
+
+            loadingBarRectTransform.sizeDelta =
+                new Vector2(Screen.width * LoadingBarWidthPercentage,
+                    LoadingBarHeight);
+
+            loadingBarOutlineRectTransform.sizeDelta =
+                new Vector2(loadingBarRectTransform.sizeDelta.x,
+                    loadingBarRectTransform.sizeDelta.y);
+
+            loadingBarFillRectTransform.sizeDelta =
+                new Vector2(0, loadingBarRectTransform.sizeDelta.y - LoadingBarFillPadding);
+        }
+
+        /// <summary>
+        /// Resets the loading bar back to 0 percent.
+        /// </summary>
+        public static void Reset()
+        {
+            var loadingBarFillRectTransform =
+                GameObject.Find(LoadingBarFillGameObjectName).GetComponent<RectTransform>();
+
+            loadingBarFillRectTransform.sizeDelta =
+                new Vector2(0, loadingBarFillRectTransform.sizeDelta.y);
+        }
+
+
+        /// <summary>
         /// Updates a loading bar by the progress made by an asynchronous operation up to a specific percentage of
         /// the loading bar. 
         /// </summary>
-        public static IEnumerator UpdateLoadingBar(AsyncOperation operation, float percentageOfLoadingBar)
+        public static IEnumerator Update(AsyncOperation operation, float percentageOfLoadingBar)
         {
             var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
 

--- a/GooglePlayInstant/LoadingScreen/LoadingBar.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingBar.cs
@@ -119,7 +119,7 @@ namespace GooglePlayInstant.LoadingScreen
 
             loadingBarOutlineRectTransform.sizeDelta = loadingBarRectTransform.sizeDelta;
             loadingBarFillRectTransform.sizeDelta =
-                new Vector2(0, loadingBarRectTransform.sizeDelta.y - LoadingBarFillPadding);
+                new Vector2(0.0f, loadingBarRectTransform.sizeDelta.y - LoadingBarFillPadding);
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace GooglePlayInstant.LoadingScreen
                 GameObject.Find(LoadingBarFillGameObjectName).GetComponent<RectTransform>();
 
             loadingBarFillRectTransform.sizeDelta =
-                new Vector2(0, loadingBarFillRectTransform.sizeDelta.y);
+                new Vector2(0.0f, loadingBarFillRectTransform.sizeDelta.y);
         }
 
 

--- a/GooglePlayInstant/LoadingScreen/LoadingBar.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingBar.cs
@@ -119,7 +119,8 @@ namespace GooglePlayInstant.LoadingScreen
         {
             var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
 
-            loadingBarRectTransform.position = new Vector2(Screen.width / 2f, Screen.height * LoadingBarYAxisPercentage);
+            loadingBarRectTransform.position =
+                new Vector2(Screen.width / 2f, Screen.height * LoadingBarYAxisPercentage);
         }
 
         /// <summary>
@@ -132,7 +133,6 @@ namespace GooglePlayInstant.LoadingScreen
                 GameObject.Find(LoadingBarFillGameObjectName).GetComponent<RectTransform>();
             var loadingBarOutlineRectTransform =
                 GameObject.Find(LoadingBarOutlineGameObjectName).GetComponent<RectTransform>();
-
 
             loadingBarRectTransform.sizeDelta =
                 new Vector2(Screen.width * LoadingBarWidthPercentage,

--- a/GooglePlayInstant/LoadingScreen/LoadingBar.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingBar.cs
@@ -41,7 +41,7 @@ namespace GooglePlayInstant.LoadingScreen
 
         // Loading bar size as a proportion of the screen size. Adjust if needed.
         private const float LoadingBarWidthProportion = 0.7f;
-        private const float LoadingBarHeightProportion = 0.1f;
+        private const float LoadingBarHeightProportion = 0.02f;
 
         // Loading bar placement as a proportion of the screen size relative to the bottom left corner. Adjust if needed.
         private const float LoadingBarPositionX = 0.5f;
@@ -100,6 +100,9 @@ namespace GooglePlayInstant.LoadingScreen
         }
 #endif
 
+        /// <summary>
+        /// Sets the position and size of the loading bar as a function of the screen heighta and width. 
+        /// </summary>
         public static void UpdateSizeAndPostition()
         {
             var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
@@ -115,37 +118,6 @@ namespace GooglePlayInstant.LoadingScreen
                 Screen.height * LoadingBarHeightProportion);
 
             loadingBarOutlineRectTransform.sizeDelta = loadingBarRectTransform.sizeDelta;
-            loadingBarFillRectTransform.sizeDelta =
-                new Vector2(0, loadingBarRectTransform.sizeDelta.y - LoadingBarFillPadding);
-        }
-
-        /// <summary>
-        /// Sets the position of the loading bar as a function of the screen height.
-        /// </summary>
-        public static void SetPosition()
-        {
-            var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
-
-            loadingBarRectTransform.position =
-                new Vector2(Screen.width * LoadingBarPositionX, Screen.height * LoadingBarPositionY);
-        }
-
-        /// <summary>
-        /// Sets the length of the loading bar and its children as a function of the screen width.
-        /// </summary>
-        public static void SetSize()
-        {
-            var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
-            var loadingBarFillRectTransform =
-                GameObject.Find(LoadingBarFillGameObjectName).GetComponent<RectTransform>();
-            var loadingBarOutlineRectTransform =
-                GameObject.Find(LoadingBarOutlineGameObjectName).GetComponent<RectTransform>();
-
-            loadingBarRectTransform.sizeDelta = new Vector2(Screen.width * LoadingBarWidthProportion,
-                Screen.height * LoadingBarHeightProportion);
-
-            loadingBarOutlineRectTransform.sizeDelta = loadingBarRectTransform.sizeDelta;
-
             loadingBarFillRectTransform.sizeDelta =
                 new Vector2(0, loadingBarRectTransform.sizeDelta.y - LoadingBarFillPadding);
         }

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -74,7 +74,6 @@ namespace GooglePlayInstant.LoadingScreen
             LoadingBar.SetPosition();
             LoadingBar.SetWidth();
             
-
             yield return LoadingBar.Update(assetbundleDownloadOperation,
                 LoadingBar.AssetBundleDownloadMaxWidthPercentage);
 

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -71,8 +71,6 @@ namespace GooglePlayInstant.LoadingScreen
             var webRequest = UnityWebRequest.GetAssetBundle(assetBundleUrl);
             var assetbundleDownloadOperation = webRequest.Send();
 #endif
-//            LoadingBar.SetPosition();
-//            LoadingBar.SetSize();
             LoadingBar.UpdateSizeAndPostition();
 
             yield return LoadingBar.Update(assetbundleDownloadOperation,

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -33,6 +33,8 @@ namespace GooglePlayInstant.LoadingScreen
 
         private IEnumerator Start()
         {
+//            Screen.orientation = ScreenOrientation.Portrait;
+
             var loadingScreenConfigJsonTextAsset =
                 Resources.Load<TextAsset>("LoadingScreenConfig");
 
@@ -54,12 +56,13 @@ namespace GooglePlayInstant.LoadingScreen
             else
             {
                 var sceneLoadOperation = SceneManager.LoadSceneAsync(_bundle.GetAllScenePaths()[0]);
-                yield return LoadingBar.UpdateLoadingBar(sceneLoadOperation, LoadingBar.SceneLoadingMaxWidthPercentage);
+
+                yield return LoadingBar.Update(sceneLoadOperation, LoadingBar.SceneLoadingMaxWidthPercentage);
             }
         }
 
         private IEnumerator GetAssetBundle(string assetBundleUrl)
-        {
+        {   
 #if UNITY_2018_1_OR_NEWER
             var webRequest = UnityWebRequestAssetBundle.GetAssetBundle(assetBundleUrl);
             var assetbundleDownloadOperation = webRequest.SendWebRequest();
@@ -70,7 +73,11 @@ namespace GooglePlayInstant.LoadingScreen
             var webRequest = UnityWebRequest.GetAssetBundle(assetBundleUrl);
             var assetbundleDownloadOperation = webRequest.Send();
 #endif
-            yield return LoadingBar.UpdateLoadingBar(assetbundleDownloadOperation,
+            LoadingBar.SetPosition();
+            LoadingBar.SetWidth();
+            
+
+            yield return LoadingBar.Update(assetbundleDownloadOperation,
                 LoadingBar.AssetBundleDownloadMaxWidthPercentage);
 
 #if UNITY_2017_1_OR_NEWER
@@ -84,6 +91,9 @@ namespace GooglePlayInstant.LoadingScreen
                     _assetBundleRetrievalAttemptCount++;
                     Debug.LogFormat("Attempt #{0} at downloading AssetBundle...", _assetBundleRetrievalAttemptCount);
                     yield return new WaitForSeconds(2);
+
+                    LoadingBar.Reset();
+
                     yield return GetAssetBundle(assetBundleUrl);
                 }
                 else

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -71,8 +71,9 @@ namespace GooglePlayInstant.LoadingScreen
             var webRequest = UnityWebRequest.GetAssetBundle(assetBundleUrl);
             var assetbundleDownloadOperation = webRequest.Send();
 #endif
-            LoadingBar.SetPosition();
-            LoadingBar.SetSize();
+//            LoadingBar.SetPosition();
+//            LoadingBar.SetSize();
+            LoadingBar.UpdateSizeAndPostition();
 
             yield return LoadingBar.Update(assetbundleDownloadOperation,
                 LoadingBar.AssetBundleDownloadMaxWidthPercentage);

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -89,6 +89,7 @@ namespace GooglePlayInstant.LoadingScreen
                     Debug.LogFormat("Attempt #{0} at downloading AssetBundle...", _assetBundleRetrievalAttemptCount);
                     yield return new WaitForSeconds(2);
 
+                    //TODO: revisit this methodology of setting the loading bar
                     LoadingBar.Reset();
 
                     yield return GetAssetBundle(assetBundleUrl);

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -60,7 +60,7 @@ namespace GooglePlayInstant.LoadingScreen
         }
 
         private IEnumerator GetAssetBundle(string assetBundleUrl)
-        {   
+        {
 #if UNITY_2018_1_OR_NEWER
             var webRequest = UnityWebRequestAssetBundle.GetAssetBundle(assetBundleUrl);
             var assetbundleDownloadOperation = webRequest.SendWebRequest();
@@ -72,8 +72,8 @@ namespace GooglePlayInstant.LoadingScreen
             var assetbundleDownloadOperation = webRequest.Send();
 #endif
             LoadingBar.SetPosition();
-            LoadingBar.SetWidth();
-            
+            LoadingBar.SetSize();
+
             yield return LoadingBar.Update(assetbundleDownloadOperation,
                 LoadingBar.AssetBundleDownloadMaxWidthPercentage);
 

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -33,8 +33,6 @@ namespace GooglePlayInstant.LoadingScreen
 
         private IEnumerator Start()
         {
-//            Screen.orientation = ScreenOrientation.Portrait;
-
             var loadingScreenConfigJsonTextAsset =
                 Resources.Load<TextAsset>("LoadingScreenConfig");
 


### PR DESCRIPTION
This is a followup of the offline conversation we had, implemented. Currently, there exists one issue with this set up, and it's related to the retry logic in a previous PR. It's in this exact case:

-The loading bar takes an AsynOperation and begins to show the progress of downloading the AssetBundle.
-The user has a network issue.
-The loading bar stops it's progress. And then there is a reattempt to download the AssetBundle.
NOTE: The loading bar is code that is a function of a given (arbitrarily) chosen percentage and an operation. It cumulatively adds to the percentage already there.
-Since the loading bar is filled already with progress made on the AssetBundle prior to the network issue, retrying the connection would cause the loading bar to extend farther than the given outline.

The current fix is an added Reset() function. Before another retry option is attempted, Reset() is called.