### PR TITLE
Updating focus control to prevent incorrect values from being displayed in tabs.

### DIFF
--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using UnityEditor;
 using UnityEngine;
 
@@ -28,8 +27,9 @@ namespace GooglePlayInstant.Editor.QuickDeploy
 
         private static int _toolbarSelectedButtonIndex;
 
-        // Keep track of the current tab and remove focus
+        // Keep track of the previous tab to remove focus if user moves to a different tab. (b/112536394)
         private static ToolBarSelectedButton _previousTab;
+
         public enum ToolBarSelectedButton
         {
             CreateBundle,
@@ -75,11 +75,11 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         {
             _toolbarSelectedButtonIndex = GUILayout.Toolbar(_toolbarSelectedButtonIndex, ToolbarButtonNames);
             var currentTab = (ToolBarSelectedButton) _toolbarSelectedButtonIndex;
-            UpdateGuiFocus(currentTab);
-            switch (/*ToolBarSelectedButton) _toolbarSelectedButtonIndex*/ currentTab)
+            UpdateGUIFocus(currentTab);
+            switch (currentTab)
             {
                 case ToolBarSelectedButton.CreateBundle:
-                  
+
                     AssetBundleBrowserClient.ReloadAndUpdateBrowserInfo();
                     OnGuiCreateBundleSelect();
                     break;
@@ -109,12 +109,13 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             GUI.enabled = true;
         }
 
-        
+
         /// <summary>
-        /// Removes the textfield focus from the tab if the user has changed the current quick deploy tab.
+        /// Unfocus the window if the user has just moved to a different quick deploy tab.
         /// </summary>
-        /// <param name="currentTab">A toolbar select button representing the tab that the user just opened.</param>
-        private static void UpdateGuiFocus(ToolBarSelectedButton currentTab)
+        /// <param name="currentTab">A ToolBarSelectedButton instance representing the current quick deploy tab.</param>
+        /// <see cref="b/112536394"/>
+        private static void UpdateGUIFocus(ToolBarSelectedButton currentTab)
         {
             if (currentTab != _previousTab)
             {

--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
@@ -79,7 +79,6 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             switch (currentTab)
             {
                 case ToolBarSelectedButton.CreateBundle:
-
                     AssetBundleBrowserClient.ReloadAndUpdateBrowserInfo();
                     OnGuiCreateBundleSelect();
                     break;

--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using UnityEditor;
 using UnityEngine;
 
@@ -27,6 +28,8 @@ namespace GooglePlayInstant.Editor.QuickDeploy
 
         private static int _toolbarSelectedButtonIndex;
 
+        // Keep track of the current tab and remove focus
+        private static ToolBarSelectedButton _previousTab;
         public enum ToolBarSelectedButton
         {
             CreateBundle,
@@ -71,9 +74,12 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         void OnGUI()
         {
             _toolbarSelectedButtonIndex = GUILayout.Toolbar(_toolbarSelectedButtonIndex, ToolbarButtonNames);
-            switch ((ToolBarSelectedButton) _toolbarSelectedButtonIndex)
+            var currentTab = (ToolBarSelectedButton) _toolbarSelectedButtonIndex;
+            UpdateGuiFocus(currentTab);
+            switch (/*ToolBarSelectedButton) _toolbarSelectedButtonIndex*/ currentTab)
             {
                 case ToolBarSelectedButton.CreateBundle:
+                  
                     AssetBundleBrowserClient.ReloadAndUpdateBrowserInfo();
                     OnGuiCreateBundleSelect();
                     break;
@@ -101,6 +107,20 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             }
 
             GUI.enabled = true;
+        }
+
+        
+        /// <summary>
+        /// Removes the textfield focus from the tab if the user has changed the current quick deploy tab.
+        /// </summary>
+        /// <param name="currentTab">A toolbar select button representing the tab that the user just opened.</param>
+        private static void UpdateGuiFocus(ToolBarSelectedButton currentTab)
+        {
+            if (currentTab != _previousTab)
+            {
+                _previousTab = currentTab;
+                GUI.FocusControl(null);
+            }
         }
 
         private void OnGuiCreateBundleSelect()


### PR DESCRIPTION
### Motivation:

Quick Deploy UI displays the wrong value in the first textfield of each tab when one of them is focused. The value in the focused textfield from one individual tab will appear in the first textfield of the next until the textfield is unfocused, which re-populates the textfields of other tabs with their original values.

### Fix:

The bug was fixed programmatically by keeping track of which tab the user has opened, and calling the GUI.FocusControl(null) method to unfocusing the Editor Window/textfield when the user moves from one tab to the other. The method is not called when the user is staying on the same tab across different onGUI calls.
