### PR TITLE
Refactored and Added AssetBundleVerifierWindow bundle tests

### DIFF
--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -48,7 +48,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         public enum AssetBundleVerifyState
         {
             InProgress,
-            DesintationError,
+            DestinationError,
             WebRequestError,
             BundleError,
             DownloadSuccess
@@ -81,7 +81,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         {
             switch (state)
             {
-                case AssetBundleVerifyState.DesintationError:
+                case AssetBundleVerifyState.DestinationError:
                     AssetBundleDownloadIsSuccessful = false;
                     ErrorDescription = "Cannot connect to destination host. See Console log for details.";
                     // No need to log since debugging information in this case is logged from thrown exception.
@@ -120,7 +120,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             catch (InvalidOperationException e)
             {
                 Debug.LogError(e.ToString());
-                return AssetBundleVerifyState.DesintationError;
+                return AssetBundleVerifyState.DestinationError;
             }
 
             _responseCode = _webRequest.responseCode;

--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -79,6 +79,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         // Visible for testing
         internal void HandleAssetBundleVerifyState(AssetBundleVerifyState state, UnityWebRequest webRequest)
         {
+            // InProgress state should not be handled.
             switch (state)
             {
                 case AssetBundleVerifyState.DestinationError:

--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using GooglePlayInstant.Tests.Editor.QuickDeploy;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -35,7 +34,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         private static UnityWebRequest _webRequest;
         private AssetBundle _bundle;
 
-        public AssetBundleVerifyState state; 
+        public AssetBundleVerifyState State; 
         
         public enum AssetBundleVerifyState
         {
@@ -73,16 +72,16 @@ namespace GooglePlayInstant.Editor.QuickDeploy
 #endif
         }
 
-        private void HandleAssetBundleVerifyState(AssetBundleVerifyState state)
+        private void HandleAssetBundleVerifyState()
         {
-            if (state == AssetBundleVerifyState.WebRequestError)
+            if (State == AssetBundleVerifyState.WebRequestError)
             {
                 _assetBundleDownloadIsSuccessful = false;
                 _errorDescription = _webRequest.error;
                 Debug.LogErrorFormat("Problem retrieving AssetBundle from {0}: {1}", _assetBundleUrl,
                     _errorDescription);
             }
-            else if (state == AssetBundleVerifyState.BundleError)
+            else if (State == AssetBundleVerifyState.BundleError)
             {
                 _assetBundleDownloadIsSuccessful = false;
                 _errorDescription = "Error extracting AssetBundle. See Console log for details.";
@@ -155,7 +154,8 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             EditorUtility.ClearProgressBar();
 
             // Performs download operation only once when webrequest is completed.
-            HandleAssetBundleVerifyState(GetAssetBundleVerifyStateInfoFromDownload(_webRequest));
+            State = GetAssetBundleVerifyStateInfoFromDownload();
+            HandleAssetBundleVerifyState();
             Repaint();
 
             // Turn request to null to signal ready for next call
@@ -165,7 +165,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
 
         private void OnGUI()
         {
-            if (state == AssetBundleVerifyState.InProgress)
+            if (State == AssetBundleVerifyState.InProgress)
             {
                 EditorGUILayout.LabelField("Loading...");
                 return;

--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
@@ -75,7 +75,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         {
             _toolbarSelectedButtonIndex = GUILayout.Toolbar(_toolbarSelectedButtonIndex, ToolbarButtonNames);
             var currentTab = (ToolBarSelectedButton) _toolbarSelectedButtonIndex;
-            UpdateGUIFocus(currentTab);
+            UpdateGuiFocus(currentTab);
             switch (currentTab)
             {
                 case ToolBarSelectedButton.CreateBundle:
@@ -114,7 +114,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         /// </summary>
         /// <param name="currentTab">A ToolBarSelectedButton instance representing the current quick deploy tab.</param>
         /// <see cref="b/112536394"/>
-        private static void UpdateGUIFocus(ToolBarSelectedButton currentTab)
+        private static void UpdateGuiFocus(ToolBarSelectedButton currentTab)
         {
             if (currentTab != _previousTab)
             {
@@ -218,8 +218,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
                 }
                 else
                 {
-                    var window = (AssetBundleVerifierWindow) GetWindow(typeof(AssetBundleVerifierWindow), true,
-                        "Play Instant AssetBundle Verify");
+                    var window = AssetBundleVerifierWindow.ShowWindow();
                     window.StartAssetBundleVerificationDownload(_assetBundleUrl);
                 }
             }

--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
@@ -198,7 +198,9 @@ namespace GooglePlayInstant.Editor.QuickDeploy
                 }
                 else
                 {
-                    AssetBundleVerifierWindow.ShowWindow(_assetBundleUrl);
+                    var window = (AssetBundleVerifierWindow) GetWindow(typeof(AssetBundleVerifierWindow), true,
+                        "Play Instant AssetBundle Verify");
+                    window.StartAssetBundleVerificationDownload(_assetBundleUrl);
                 }
             }
 

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
@@ -11,14 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
+
+using System.Collections;
 using GooglePlayInstant.Editor.QuickDeploy;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEngine;
+using UnityEngine.Networking;
 using UnityEngine.TestTools;
 
 namespace GooglePlayInstant.Tests.Editor.QuickDeploy
@@ -29,12 +28,62 @@ namespace GooglePlayInstant.Tests.Editor.QuickDeploy
     [TestFixture]
     public class AssetBundleVerifierTest
     {
-
-        [Test]
-        public void TestGetAuthorizationResponse()
+        [UnityTest]
+        public IEnumerator TestDestinationError()
         {
-            
+            var window = (AssetBundleVerifierWindow) EditorWindow.GetWindow(typeof(AssetBundleVerifierWindow), true,
+                "Play Instant AssetBundle Verify");
+
+            while (window == null)
+            {
+                yield return null;
+            }
+
+            window.HandleAssetBundleVerifyState(AssetBundleVerifierWindow.AssetBundleVerifyState.DesintationError,
+                new UnityWebRequest());
+
+            Assert.AreEqual(false, window.AssetBundleDownloadIsSuccessful,
+                "AssetBundle download should not be marked successful during destination error state.");
         }
 
+        [UnityTest]
+        public IEnumerator TestWebRequestError()
+        {
+            var window = (AssetBundleVerifierWindow) EditorWindow.GetWindow(typeof(AssetBundleVerifierWindow), true,
+                "Play Instant AssetBundle Verify");
+
+            while (window == null)
+            {
+                yield return null;
+            }
+
+            window.HandleAssetBundleVerifyState(AssetBundleVerifierWindow.AssetBundleVerifyState.WebRequestError,
+                new UnityWebRequest());
+
+            Assert.AreEqual(false, window.AssetBundleDownloadIsSuccessful,
+                "AssetBundle download should not be marked successful during destination error state.");
+
+            LogAssert.Expect(LogType.Error,
+                string.Format(AssetBundleVerifierWindow.WebRequestErrorFormatMessage, window.AssetBundleUrl,
+                    window.ErrorDescription));
+        }
+
+        [UnityTest]
+        public IEnumerator TestBundleError()
+        {
+            var window = (AssetBundleVerifierWindow) EditorWindow.GetWindow(typeof(AssetBundleVerifierWindow), true,
+                "Play Instant AssetBundle Verify");
+
+            while (window == null)
+            {
+                yield return null;
+            }
+
+            window.HandleAssetBundleVerifyState(AssetBundleVerifierWindow.AssetBundleVerifyState.BundleError,
+                new UnityWebRequest());
+
+            Assert.AreEqual(false, window.AssetBundleDownloadIsSuccessful,
+                "AssetBundle download should not be marked successful during bundle error state.");
+        }
     }
 }

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using GooglePlayInstant.Editor.QuickDeploy;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace GooglePlayInstant.Tests.Editor.QuickDeploy
+{
+    /// <summary>
+    /// Contains unit tests for AssetBundleVerifier methods.
+    /// </summary>
+    [TestFixture]
+    public class AssetBundleVerifierTest
+    {
+
+        [Test]
+        public void TestGetAuthorizationResponse()
+        {
+            
+        }
+
+    }
+}

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections;
 using GooglePlayInstant.Editor.QuickDeploy;
 using NUnit.Framework;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.Networking;
 using UnityEngine.TestTools;
@@ -38,7 +36,7 @@ namespace GooglePlayInstant.Tests.Editor.QuickDeploy
 
             Assert.IsFalse(window.AssetBundleDownloadIsSuccessful,
                 "AssetBundle download should not be marked successful during destination error state.");
-            
+
             window.Close();
         }
 
@@ -56,7 +54,7 @@ namespace GooglePlayInstant.Tests.Editor.QuickDeploy
             LogAssert.Expect(LogType.Error,
                 string.Format(AssetBundleVerifierWindow.WebRequestErrorFormatMessage, window.AssetBundleUrl,
                     window.ErrorDescription));
-            
+
             window.Close();
         }
 
@@ -70,7 +68,7 @@ namespace GooglePlayInstant.Tests.Editor.QuickDeploy
 
             Assert.IsFalse(window.AssetBundleDownloadIsSuccessful,
                 "AssetBundle download should not be marked successful during bundle error state.");
-            
+
             window.Close();
         }
     }

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
@@ -39,7 +39,7 @@ namespace GooglePlayInstant.Tests.Editor.QuickDeploy
                 yield return null;
             }
 
-            window.HandleAssetBundleVerifyState(AssetBundleVerifierWindow.AssetBundleVerifyState.DesintationError,
+            window.HandleAssetBundleVerifyState(AssetBundleVerifierWindow.AssetBundleVerifyState.DestinationError,
                 new UnityWebRequest());
 
             Assert.AreEqual(false, window.AssetBundleDownloadIsSuccessful,

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
@@ -23,7 +23,7 @@ using UnityEngine.TestTools;
 namespace GooglePlayInstant.Tests.Editor.QuickDeploy
 {
     /// <summary>
-    /// Contains unit tests for AssetBundleVerifier methods.
+    /// Contains tests for each of AssetBundleVerifier error states.
     /// </summary>
     [TestFixture]
     public class AssetBundleVerifierTest

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
@@ -28,62 +28,50 @@ namespace GooglePlayInstant.Tests.Editor.QuickDeploy
     [TestFixture]
     public class AssetBundleVerifierTest
     {
-        [UnityTest]
-        public IEnumerator TestDestinationError()
+        [Test]
+        public void TestDestinationError()
         {
-            var window = (AssetBundleVerifierWindow) EditorWindow.GetWindow(typeof(AssetBundleVerifierWindow), true,
-                "Play Instant AssetBundle Verify");
-
-            while (window == null)
-            {
-                yield return null;
-            }
+            var window = AssetBundleVerifierWindow.ShowWindow();
 
             window.HandleAssetBundleVerifyState(AssetBundleVerifierWindow.AssetBundleVerifyState.DestinationError,
                 new UnityWebRequest());
 
-            Assert.AreEqual(false, window.AssetBundleDownloadIsSuccessful,
+            Assert.IsFalse(window.AssetBundleDownloadIsSuccessful,
                 "AssetBundle download should not be marked successful during destination error state.");
+            
+            window.Close();
         }
 
-        [UnityTest]
-        public IEnumerator TestWebRequestError()
+        [Test]
+        public void TestWebRequestError()
         {
-            var window = (AssetBundleVerifierWindow) EditorWindow.GetWindow(typeof(AssetBundleVerifierWindow), true,
-                "Play Instant AssetBundle Verify");
-
-            while (window == null)
-            {
-                yield return null;
-            }
+            var window = AssetBundleVerifierWindow.ShowWindow();
 
             window.HandleAssetBundleVerifyState(AssetBundleVerifierWindow.AssetBundleVerifyState.WebRequestError,
                 new UnityWebRequest());
 
-            Assert.AreEqual(false, window.AssetBundleDownloadIsSuccessful,
+            Assert.IsFalse(window.AssetBundleDownloadIsSuccessful,
                 "AssetBundle download should not be marked successful during destination error state.");
 
             LogAssert.Expect(LogType.Error,
                 string.Format(AssetBundleVerifierWindow.WebRequestErrorFormatMessage, window.AssetBundleUrl,
                     window.ErrorDescription));
+            
+            window.Close();
         }
 
-        [UnityTest]
-        public IEnumerator TestBundleError()
+        [Test]
+        public void TestBundleError()
         {
-            var window = (AssetBundleVerifierWindow) EditorWindow.GetWindow(typeof(AssetBundleVerifierWindow), true,
-                "Play Instant AssetBundle Verify");
-
-            while (window == null)
-            {
-                yield return null;
-            }
+            var window = AssetBundleVerifierWindow.ShowWindow();
 
             window.HandleAssetBundleVerifyState(AssetBundleVerifierWindow.AssetBundleVerifyState.BundleError,
                 new UnityWebRequest());
 
-            Assert.AreEqual(false, window.AssetBundleDownloadIsSuccessful,
+            Assert.IsFalse(window.AssetBundleDownloadIsSuccessful,
                 "AssetBundle download should not be marked successful during bundle error state.");
+            
+            window.Close();
         }
     }
 }


### PR DESCRIPTION
Refactored code to now support tests for all three error states: 

- DestinationError,
- WebRequestError,
- BundleError

