### PR TITLE
Reuse refresh token to maintain authorization throughout an entire unity session.

### DIFF
--- a/GooglePlayInstant/Editor/QuickDeploy/AccessTokenGetter.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AccessTokenGetter.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 

--- a/GooglePlayInstant/Editor/QuickDeploy/AccessTokenGetter.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AccessTokenGetter.cs
@@ -262,7 +262,6 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             /// </summary>
             internal static string RefreshToken { get; private set; }
 
-
             /// <summary>
             ///  The value of the current access token if available.
             /// </summary>

--- a/GooglePlayInstant/Editor/QuickDeploy/AccessTokenGetter.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AccessTokenGetter.cs
@@ -51,8 +51,8 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         }
 
         /// <summary>
-        /// Get new access token if access token is expired or is not available, and execute the action when the access
-        /// token is available.
+        /// Retrieves and stores a new access token if the token is expired or is not available, and executse the post
+        /// toke action when the access token is available.
         /// </summary>
         /// <param name="postTokenAction">Action to be executed when valid access token is avalable.</param>
         public static void ValidateAccessToken(Action postTokenAction)
@@ -77,15 +77,13 @@ namespace GooglePlayInstant.Editor.QuickDeploy
 
 
         /// <summary>
-        /// Instantiate the OAuth2 flow to retrieve authorization code for google cloud storage, and schedule
-        /// invocation of the code handler on the received authorization code once it is available or throw an exception
-        /// once there is a failure to get the authorization code.
+        /// Instantiates the OAuth2 flow to retrieve authorization code for google cloud storage, and schedules
+        /// invocation of the code handler on the received authorization code once it is available. Tthrows an exception
+        /// once there is a failure to get the authorization code from the oauth2 flow.
         /// </summary>
         /// <param name="onAuthorizationCodeAction">An action to invoke on the authorization code instance when it is
         /// available.</param>
-        /// <exception cref="Exception">Exception thrown when required authorization code cannot be received
-        /// from OAuth2 flow.</exception>
-        public static void GetAuthCode(Action<AuthorizationCode> onAuthorizationCodeAction)
+        private static void GetAuthCode(Action<AuthorizationCode> onAuthorizationCodeAction)
         {
             var server = new OAuth2Server(authorizationResponse => { _authorizationResponse = authorizationResponse; });
             server.Start();
@@ -158,7 +156,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         /// Sends an HTTP request to OAuth2 token uri to retrieve, process and store needed tokens.
         /// </summary>
         /// <param name="grantDictionary">A dictionary containing OAuth2 grant type and grant values to be used when
-        /// requesting access token. <see cref=""/></param>
+        /// requesting access token.</param>
         /// <param name="postTokenAction"></param>
         private static void RequestToken(Dictionary<string, string> grantDictionary, Action postTokenAction)
         {
@@ -179,9 +177,10 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         }
 
         /// <summary>
-        /// Handles received response from a token request by parsing the response to update access and refresh tokens
+        /// Handles received response from a token request by parsing the response to update access and refresh token
         /// values if available, as well as throwing an error when there was a failure getting required tokens.
         /// </summary>
+        /// <param name="completeTokenRequest">A www instance holding a token  request that has received a response.</param>
         private static void HandleTokenResponse(WWW completeTokenRequest)
         {
             var responseError = completeTokenRequest.error;
@@ -207,7 +206,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         /// Represents authorization code received from OAuth2 Protocol when the user authorizes the application to
         /// access the cloud, and is used to get an access token used for making API requests.
         /// </summary>
-        public class AuthorizationCode
+        private class AuthorizationCode
         {
             public string Code;
             public string RedirectUri;
@@ -216,8 +215,9 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         /// <summary>
         /// Represents the JSON body of the access token response returned by Google Cloud OAuth2 API.
         /// </summary>
+#pragma warning disable CS0649
         [Serializable]
-        public class GcpAccessTokenResponse
+        private class GcpAccessTokenResponse
         {
             // Fields are named snake_case style to match the format of the JSON response returned by GCP OAuth2 API.
 
@@ -266,11 +266,10 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             /// Update values of access and refresh tokens, as well as the time it will take for the new token to
             /// expire. The refreshToken parameter is only used if it is not null or empty.
             /// </summary>
-            /// <param name="expiresIn">Seconds until the access token expires.</param>
-            internal static void Update(string accessToken, string refreshToken, int expiresIn)
+            internal static void Update(string accessToken, string refreshToken, int secondsToExpiration)
             {
                 Value = accessToken;
-                _expiresAt = DateTime.Now.AddSeconds(expiresIn - TokenExpirationOffsetInSeconds);
+                _expiresAt = DateTime.Now.AddSeconds(secondsToExpiration - TokenExpirationOffsetInSeconds);
 
                 if (!string.IsNullOrEmpty(refreshToken))
                 {

--- a/GooglePlayInstant/Editor/QuickDeploy/AccessTokenGetter.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AccessTokenGetter.cs
@@ -150,8 +150,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             };
             RequestToken(grantDictionary, postTokenAction);
         }
-
-
+        
         /// <summary>
         /// Sends an HTTP request to OAuth2 token uri to retrieve, process and store needed tokens.
         /// </summary>

--- a/GooglePlayInstant/Editor/QuickDeploy/GcpClient.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/GcpClient.cs
@@ -215,10 +215,9 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         private static void InvokeAccessRestrictedAction(
             Action<Action<WWW>> initialAction, Action<WWW> postResponseAction)
         {
-            var token = AccessTokenGetter.AccessToken;
-            if (token == null)
+            if (!AccessTokenGetter.AccessToken.IsValid())
             {
-                AccessTokenGetter.UpdateAccessToken(() => initialAction(postResponseAction));
+                AccessTokenGetter.ValidateAccessToken(() => initialAction(postResponseAction));
             }
             else
             {
@@ -248,7 +247,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         {
             var dictionaryWithAuthorizationHeader = new Dictionary<string, string>
             {
-                {"Authorization", string.Format("Bearer {0}", AccessTokenGetter.AccessToken.access_token)}
+                {"Authorization", string.Format("Bearer {0}", AccessTokenGetter.AccessToken.Value)}
             };
             return dictionaryWithAuthorizationHeader.Union(headers ?? new Dictionary<string, string>())
                 .ToDictionary(pair => pair.Key, pair => pair.Value);

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/AccessTokenGetterTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/AccessTokenGetterTest.cs
@@ -1,0 +1,63 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GooglePlayInstant.Editor.QuickDeploy;
+using NUnit.Framework;
+
+namespace GooglePlayInstant.Tests.Editor.QuickDeploy
+{
+    /// <summary>
+    /// Contains tests for the AccessTokenGetter class.
+    /// </summary>
+    [TestFixture]
+    public class AccessTokenGetterTest
+    {
+        [Test]
+        public void TestStartsWithInvalidAccesstoken()
+        {
+            Assert.IsFalse(AccessTokenGetter.AccessToken.IsValid());
+        }
+
+        [Test]
+        public void TestHasCorrectAccessAndRefreshTokenValues()
+        {
+            // Ensure that new created access token has a correct value.
+            const string firstAccessToken = "accessToken";
+            const string firstRefreshToken = "refreshToken";
+            var firstGcpcessToken = new AccessTokenGetter.GcpAccessToken(firstAccessToken, firstRefreshToken, 10);
+            Assert.AreEqual(firstAccessToken, firstGcpcessToken.Value);
+            // Ensure that refresh token has been shared by the entire class.
+            Assert.AreEqual(firstRefreshToken, AccessTokenGetter.GcpAccessToken.RefreshToken);
+
+            // Create new token instances with null and empty refresh tokens, which should not replace the first refresh token.
+            const string secondAccessToken = "secondAccessToken";
+            var secondGcpAccessToken = new AccessTokenGetter.GcpAccessToken(secondAccessToken, null, 10);
+            var thirdGcpAccessToken = new AccessTokenGetter.GcpAccessToken(secondAccessToken, "", 10);
+            // Ensure that created token has correct value, and that the refresh token is not different from the first valid one.
+            Assert.AreEqual(secondAccessToken, secondGcpAccessToken.Value);
+            Assert.AreEqual(secondAccessToken, thirdGcpAccessToken.Value);
+            Assert.AreEqual(firstRefreshToken, AccessTokenGetter.GcpAccessToken.RefreshToken);
+
+
+            // Ensure that the refresh token is updated when a new valid one is available.
+            const string thirdAccessToken = "thirdAccessToken";
+            const string thirdRefreshToken = "thirdRefreshToken";
+            // Pass new refresh token
+            var fourthGcpAccessToken = new AccessTokenGetter.GcpAccessToken(thirdAccessToken, thirdRefreshToken, 10);
+            Assert.AreEqual(thirdAccessToken, fourthGcpAccessToken.Value);
+            // Ensure that the shared refresh token has been updated this time.
+            Assert.AreEqual(thirdRefreshToken, AccessTokenGetter.GcpAccessToken.RefreshToken);
+        }
+    }
+}

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/AccessTokenGetterTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/AccessTokenGetterTest.cs
@@ -23,6 +23,8 @@ namespace GooglePlayInstant.Tests.Editor.QuickDeploy
     [TestFixture]
     public class AccessTokenGetterTest
     {
+        private static int HourInSeconds = 3600;
+
         [Test]
         public void TestStartsWithInvalidAccesstoken()
         {
@@ -30,20 +32,28 @@ namespace GooglePlayInstant.Tests.Editor.QuickDeploy
         }
 
         [Test]
+        public void TestAccessTokenIsValid()
+        {
+            Assert.IsTrue(new AccessTokenGetter.GcpAccessToken("Access", "Refresh", HourInSeconds).IsValid());
+            Assert.IsFalse(new AccessTokenGetter.GcpAccessToken("Access", "Refresh", -1).IsValid());
+        }
+
+        [Test]
         public void TestHasCorrectAccessAndRefreshTokenValues()
         {
             // Ensure that new created access token has a correct value.
-            const string firstAccessToken = "accessToken";
-            const string firstRefreshToken = "refreshToken";
-            var firstGcpcessToken = new AccessTokenGetter.GcpAccessToken(firstAccessToken, firstRefreshToken, 10);
+            const string firstAccessToken = "firstAccessToken";
+            const string firstRefreshToken = "firstRefreshToken";
+            var firstGcpcessToken =
+                new AccessTokenGetter.GcpAccessToken(firstAccessToken, firstRefreshToken, HourInSeconds);
             Assert.AreEqual(firstAccessToken, firstGcpcessToken.Value);
             // Ensure that refresh token has been shared by the entire class.
             Assert.AreEqual(firstRefreshToken, AccessTokenGetter.GcpAccessToken.RefreshToken);
 
             // Create new token instances with null and empty refresh tokens, which should not replace the first refresh token.
             const string secondAccessToken = "secondAccessToken";
-            var secondGcpAccessToken = new AccessTokenGetter.GcpAccessToken(secondAccessToken, null, 10);
-            var thirdGcpAccessToken = new AccessTokenGetter.GcpAccessToken(secondAccessToken, "", 10);
+            var secondGcpAccessToken = new AccessTokenGetter.GcpAccessToken(secondAccessToken, null, HourInSeconds);
+            var thirdGcpAccessToken = new AccessTokenGetter.GcpAccessToken(secondAccessToken, "", HourInSeconds);
             // Ensure that created token has correct value, and that the refresh token is not different from the first valid one.
             Assert.AreEqual(secondAccessToken, secondGcpAccessToken.Value);
             Assert.AreEqual(secondAccessToken, thirdGcpAccessToken.Value);
@@ -54,7 +64,8 @@ namespace GooglePlayInstant.Tests.Editor.QuickDeploy
             const string thirdAccessToken = "thirdAccessToken";
             const string thirdRefreshToken = "thirdRefreshToken";
             // Pass new refresh token
-            var fourthGcpAccessToken = new AccessTokenGetter.GcpAccessToken(thirdAccessToken, thirdRefreshToken, 10);
+            var fourthGcpAccessToken =
+                new AccessTokenGetter.GcpAccessToken(thirdAccessToken, thirdRefreshToken, HourInSeconds);
             Assert.AreEqual(thirdAccessToken, fourthGcpAccessToken.Value);
             // Ensure that the shared refresh token has been updated this time.
             Assert.AreEqual(thirdRefreshToken, AccessTokenGetter.GcpAccessToken.RefreshToken);


### PR DESCRIPTION
Throughout an unity session, user authorizes once, and the received refresh token from the first token response is reused to get new access tokens after the first token has expired.